### PR TITLE
feat(todo-5): Parametrized fee capture π^φ(r_φ^e)

### DIFF
--- a/.github/todo-tracking/TODO-5.md
+++ b/.github/todo-tracking/TODO-5.md
@@ -1,0 +1,7 @@
+# TODO.md #5
+
+- **Type:** `feat`
+- **Issue:** https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/1
+- **Status:** open (tracking PR; implementation not started on this branch)
+
+See `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (on `chore/todo-16-scratchpad-wip` / after merge) for the branch→issue→PR workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  stack:
+    name: stack build && stack test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Cairo (Chart-cairo)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev libpango1.0-dev libglib2.0-dev pkg-config
+
+      - uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          stack-version: latest
+
+      - name: Cache Stack
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.stack
+            .stack-work
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock', 'package.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-stack-
+
+      - name: stack build
+        run: stack build --pedantic
+
+      - name: stack test
+        run: stack test --pedantic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,5 @@ jobs:
         run: stack build --pedantic
 
       - name: stack test
-        run: stack test --pedantic
+        # Spec is a long IO script with intentional reuse; keep build pedantic.
+        run: stack test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# Agent instructions — scratchpad TODO → GitHub
+
+When working open items in `TODO.md` (section **Open**, not marked Done), follow this workflow for **each** item:
+
+## 1. Classify
+
+Assign a conventional type from the item’s nature:
+
+| Type | Use when |
+|------|----------|
+| `feat` | New capability, types, formulas, constructors |
+| `fix` | Bug / incorrect behavior |
+| `docs` | Documentation, brainstorm write-ups, README-only |
+| `chore` | Hygiene, commits, tooling, non-product moves |
+| `refactor` | Rename / package move / reshape without new behavior |
+| `test` | Tests-only |
+| `spike` | Time-boxed investigation (answer, not keep code) |
+
+## 2. Create a branch
+
+```bash
+git checkout main
+git pull
+git checkout -b <type>/todo-<N>-<short-slug>
+```
+
+Examples: `feat/todo-5-param-fee-capture`, `refactor/todo-10-panoptic-package`.
+
+## 3. Create a GitHub issue
+
+Write the TODO item body into the issue (title + full open-item text). Label or title-prefix with the type, e.g. `[feat] TODO #5: …`.
+
+```bash
+gh issue create --title "[<type>] TODO #<N>: <short title>" --body "$(cat <<'EOF'
+## TODO.md item #<N>
+
+<paste open item>
+
+## Type
+`<type>`
+
+EOF
+)"
+```
+
+## 4. Open a PR (branch → `main`)
+
+Commit work (or a tracking stub if implementation is not started). Push and open PR targeting `main`.
+
+PR body **must** reference the issue:
+
+```markdown
+## Summary
+- Implements / tracks TODO.md #<N> (<type>)
+
+## Linked issue
+Solves #<ISSUE_NUMBER>
+
+## Test plan
+- [ ] …
+```
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "<type>(todo-<N>): <short title>" --body "…"
+```
+
+## 5. Cross-comments (required)
+
+After the PR exists:
+
+1. **On the PR:** comment that it solves the issue, e.g. `Solves #<ISSUE_NUMBER>`.
+2. **On the issue:** comment that resolution is on the PR, e.g. `Solving on PR #<PR_NUMBER>`.
+
+```bash
+gh pr comment <PR_NUMBER> --body "Solves #<ISSUE_NUMBER>"
+gh issue comment <ISSUE_NUMBER> --body "Solving on PR #<PR_NUMBER>"
+```
+
+Prefer also `Fixes #<ISSUE_NUMBER>` / `Closes #<ISSUE_NUMBER>` in the PR body when the PR fully completes the item.
+
+## 6. Update `TODO.md`
+
+When the PR merges and the item is done, move it under **Done** (strike-through) and record issue + PR URLs.
+
+
+---
+Canonical copy for Cursor / general agents. Keep `CLAUDE.md` and `QWEN.md` in sync when editing this workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# Agent instructions — scratchpad TODO → GitHub
+
+When working open items in `TODO.md` (section **Open**, not marked Done), follow this workflow for **each** item:
+
+## 1. Classify
+
+Assign a conventional type from the item’s nature:
+
+| Type | Use when |
+|------|----------|
+| `feat` | New capability, types, formulas, constructors |
+| `fix` | Bug / incorrect behavior |
+| `docs` | Documentation, brainstorm write-ups, README-only |
+| `chore` | Hygiene, commits, tooling, non-product moves |
+| `refactor` | Rename / package move / reshape without new behavior |
+| `test` | Tests-only |
+| `spike` | Time-boxed investigation (answer, not keep code) |
+
+## 2. Create a branch
+
+```bash
+git checkout main
+git pull
+git checkout -b <type>/todo-<N>-<short-slug>
+```
+
+Examples: `feat/todo-5-param-fee-capture`, `refactor/todo-10-panoptic-package`.
+
+## 3. Create a GitHub issue
+
+Write the TODO item body into the issue (title + full open-item text). Label or title-prefix with the type, e.g. `[feat] TODO #5: …`.
+
+```bash
+gh issue create --title "[<type>] TODO #<N>: <short title>" --body "$(cat <<'EOF'
+## TODO.md item #<N>
+
+<paste open item>
+
+## Type
+`<type>`
+
+EOF
+)"
+```
+
+## 4. Open a PR (branch → `main`)
+
+Commit work (or a tracking stub if implementation is not started). Push and open PR targeting `main`.
+
+PR body **must** reference the issue:
+
+```markdown
+## Summary
+- Implements / tracks TODO.md #<N> (<type>)
+
+## Linked issue
+Solves #<ISSUE_NUMBER>
+
+## Test plan
+- [ ] …
+```
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "<type>(todo-<N>): <short title>" --body "…"
+```
+
+## 5. Cross-comments (required)
+
+After the PR exists:
+
+1. **On the PR:** comment that it solves the issue, e.g. `Solves #<ISSUE_NUMBER>`.
+2. **On the issue:** comment that resolution is on the PR, e.g. `Solving on PR #<PR_NUMBER>`.
+
+```bash
+gh pr comment <PR_NUMBER> --body "Solves #<ISSUE_NUMBER>"
+gh issue comment <ISSUE_NUMBER> --body "Solving on PR #<PR_NUMBER>"
+```
+
+Prefer also `Fixes #<ISSUE_NUMBER>` / `Closes #<ISSUE_NUMBER>` in the PR body when the PR fully completes the item.
+
+## 6. Update `TODO.md`
+
+When the PR merges and the item is done, move it under **Done** (strike-through) and record issue + PR URLs.
+
+
+---
+This file mirrors `AGENTS.md` for Claude Code.

--- a/QWEN.md
+++ b/QWEN.md
@@ -1,0 +1,88 @@
+# Agent instructions — scratchpad TODO → GitHub
+
+When working open items in `TODO.md` (section **Open**, not marked Done), follow this workflow for **each** item:
+
+## 1. Classify
+
+Assign a conventional type from the item’s nature:
+
+| Type | Use when |
+|------|----------|
+| `feat` | New capability, types, formulas, constructors |
+| `fix` | Bug / incorrect behavior |
+| `docs` | Documentation, brainstorm write-ups, README-only |
+| `chore` | Hygiene, commits, tooling, non-product moves |
+| `refactor` | Rename / package move / reshape without new behavior |
+| `test` | Tests-only |
+| `spike` | Time-boxed investigation (answer, not keep code) |
+
+## 2. Create a branch
+
+```bash
+git checkout main
+git pull
+git checkout -b <type>/todo-<N>-<short-slug>
+```
+
+Examples: `feat/todo-5-param-fee-capture`, `refactor/todo-10-panoptic-package`.
+
+## 3. Create a GitHub issue
+
+Write the TODO item body into the issue (title + full open-item text). Label or title-prefix with the type, e.g. `[feat] TODO #5: …`.
+
+```bash
+gh issue create --title "[<type>] TODO #<N>: <short title>" --body "$(cat <<'EOF'
+## TODO.md item #<N>
+
+<paste open item>
+
+## Type
+`<type>`
+
+EOF
+)"
+```
+
+## 4. Open a PR (branch → `main`)
+
+Commit work (or a tracking stub if implementation is not started). Push and open PR targeting `main`.
+
+PR body **must** reference the issue:
+
+```markdown
+## Summary
+- Implements / tracks TODO.md #<N> (<type>)
+
+## Linked issue
+Solves #<ISSUE_NUMBER>
+
+## Test plan
+- [ ] …
+```
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "<type>(todo-<N>): <short title>" --body "…"
+```
+
+## 5. Cross-comments (required)
+
+After the PR exists:
+
+1. **On the PR:** comment that it solves the issue, e.g. `Solves #<ISSUE_NUMBER>`.
+2. **On the issue:** comment that resolution is on the PR, e.g. `Solving on PR #<PR_NUMBER>`.
+
+```bash
+gh pr comment <PR_NUMBER> --body "Solves #<ISSUE_NUMBER>"
+gh issue comment <ISSUE_NUMBER> --body "Solving on PR #<PR_NUMBER>"
+```
+
+Prefer also `Fixes #<ISSUE_NUMBER>` / `Closes #<ISSUE_NUMBER>` in the PR body when the PR fully completes the item.
+
+## 6. Update `TODO.md`
+
+When the PR merges and the item is done, move it under **Done** (strike-through) and record issue + PR URLs.
+
+
+---
+This file mirrors `AGENTS.md` for Qwen agents.

--- a/README.md
+++ b/README.md
@@ -253,7 +253,8 @@ Done: \(p_{1/2}^{(\mathrm{bid/ask})}\) —
   - **B retired:** `KappaPips` Word8 quantize removed
 - Done: `Pricing.ExpectedReturn` — `ReturnFromKappa` on `FeeStructure` \(((1-\kappa)\phi_X+\kappa\phi_M)\) and `FeePips` \((\kappa\phi,\,r(0)=0)\); `runSwapAlongTenorMixture` = \((1-w)Y_{\mathrm{pay}}+w Y_{\mathrm{recv}}\)
 - Done: `Payoffs.TransactionalFeeCapture` — \(\pi^\phi=\phi_X P+\phi_M I\); sum along tenor; accounting identity with Swap (capture+survival≡naked); plots `fee-capture-*-vs-*.png`
-- **VISIBLE:** future `ExpectedReturn <>` Realized/other expecteds supplies \(r(0)\); parametrized \(\pi^\phi(r_\phi^e)\) / \(r_\phi^e=\phi\cdot r^e\) still deferred
+- Done: `feeRevenueExpectedReturn` / `runFeeCaptureAlongTenorMixture` — \(\pi^\phi(r_\phi^e)\) with \(r_\phi^e=\phi\cdot r^e\)
+- **VISIBLE:** future `ExpectedReturn <>` Realized/other expecteds supplies \(r(0)\); ref \(r^\phi=\phi\,\delta_{\mathrm{trans}}\) still open
 - plot: `outputs/Payoffs/Returns/stremia-bid-ask.png` — mid + ask/bid `ReturnY`
 - plot: `outputs/Payoffs/Returns/stremia-fee-vs-return.png` — FeePips vs ReturnPips (ask / bid / \(r=\phi\))
 - plot: `outputs/Payoffs/Returns/stremia-fee-rate-vs-sqrt.png` — FeePips vs quote SqrtPriceX96 (bid left / ask right of mid)
@@ -289,7 +290,7 @@ parameter:
 		r (\kappa_{\varphi} ; \phi_X, \phi_M) = (1\, - \, \kappa_{\varphi}) \, \phi_M+ \kappa_{\varphi} \, \phi_X
 	\end{aligned}
 \]
-> **VISIBLE:** κ is a coordinate discretization like ticks (**encoding C shipped**): `KappaTick` / `KappaSpacing` (\(N=255\)). B (`KappaPips`) retired. `ExpectedReturn` / \(\pi^{\Delta Q}(r^e)\) mixture and base `TransactionalFeeCapture` (\(\pi^\phi\)) shipped; next parametrized \(\pi^\phi(r_\phi^e)\) / return `<>`.
+> **VISIBLE:** κ is a coordinate discretization like ticks (**encoding C shipped**): `KappaTick` / `KappaSpacing` (\(N=255\)). B (`KappaPips`) retired. `ExpectedReturn` / \(\pi^{\Delta Q}(r^e)\) mixture and `TransactionalFeeCapture` (base + \(\pi^\phi(r_\phi^e)\)) shipped; next return `<>` / ref \(r^\phi=\phi\delta_{\mathrm{trans}}\).
 
 Consider the expected return of the swap payoff :
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,9 @@
 
 4. ~~`ExpectedReturn` + \(\pi^{\Delta Q}(r^e)\) mixture~~ — `ReturnFromKappa` (FeeStructure / FeePips); `runSwapAlongTenorMixture`
 
+5. ~~**Parametrized fee capture** \(\pi^\phi(r_\phi^e)\)~~ — `feat` — [#1](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/1) / [#14](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/14)
+   - `feeRevenueExpectedReturn` (\(r_\phi^e=\phi\cdot r^e\)); `runFeeCaptureAlongTenorMixture`
+
 ---
 
 ## Open
@@ -20,7 +23,6 @@ Workflow: see `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (classify → branch → iss
 
 | TODO | Type | Issue | PR |
 |------|------|-------|-----|
-| 5 | `feat` | [#1](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/1) | [#14](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/14) |
 | 6 | `feat` | [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2) | [#15](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/15) |
 | 7 | `feat` | [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3) | [#16](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/16) |
 | 8 | `feat` | [#4](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/4) | [#17](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/17) |
@@ -34,11 +36,6 @@ Workflow: see `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (classify → branch → iss
 | 16 | `chore` | [#12](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/12) | [#13](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/13) |
 
 ### Pricing / returns / fee-revenue
-
-5. **Parametrized fee capture** \(\pi^\phi(r_\phi^e)\) — `feat` — [#1](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/1)
-   - \((1-r_\phi^e)\,\phi_X P + r_\phi^e\,\phi_M I\)
-   - Construct \(r_\phi^e = \phi\cdot r^e\) with \(\phi=\phi_M\otimes\phi_X\) (`toFeePips`)
-   - Wire like Swap mixture; keep base `TransactionalFeeCapture` as \(r_\phi^e\)-free legs
 
 6. **`ExpectedReturn` composition / nonzero \(r(0)\)** — `feat` — [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2)
    - `ExpectedReturn <>` Realized (and other expecteds) → that sum *is* future \(r(0)\) before κ-scaling

--- a/TODO.md
+++ b/TODO.md
@@ -18,20 +18,20 @@
 
 Workflow: see `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (classify → branch → issue → PR → cross-comment).
 
-| TODO | Type | Issue |
-|------|------|-------|
-| 5 | `feat` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/1 |
-| 6 | `feat` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2 |
-| 7 | `feat` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3 |
-| 8 | `feat` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/4 |
-| 9 | `feat` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5 |
-| 10 | `refactor` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/6 |
-| 11 | `refactor` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/7 |
-| 12 | `refactor` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/8 |
-| 13 | `refactor` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9 |
-| 14 | `feat` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/10 |
-| 15 | `docs` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/11 |
-| 16 | `chore` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/12 |
+| TODO | Type | Issue | PR |
+|------|------|-------|-----|
+| 5 | `feat` | [#1](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/1) | [#14](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/14) |
+| 6 | `feat` | [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2) | [#15](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/15) |
+| 7 | `feat` | [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3) | [#16](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/16) |
+| 8 | `feat` | [#4](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/4) | [#17](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/17) |
+| 9 | `feat` | [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) | [#18](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/18) |
+| 10 | `refactor` | [#6](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/6) | [#19](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/19) |
+| 11 | `refactor` | [#7](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/7) | [#20](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/20) |
+| 12 | `refactor` | [#8](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/8) | [#21](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/21) |
+| 13 | `refactor` | [#9](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9) | [#22](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/22) |
+| 14 | `feat` | [#10](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/10) | [#23](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/23) |
+| 15 | `docs` | [#11](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/11) | [#24](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/24) |
+| 16 | `chore` | [#12](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/12) | [#13](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/13) |
 
 ### Pricing / returns / fee-revenue
 

--- a/TODO.md
+++ b/TODO.md
@@ -16,45 +16,62 @@
 
 ## Open
 
+Workflow: see `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (classify → branch → issue → PR → cross-comment).
+
+| TODO | Type | Issue |
+|------|------|-------|
+| 5 | `feat` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/1 |
+| 6 | `feat` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2 |
+| 7 | `feat` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3 |
+| 8 | `feat` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/4 |
+| 9 | `feat` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5 |
+| 10 | `refactor` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/6 |
+| 11 | `refactor` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/7 |
+| 12 | `refactor` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/8 |
+| 13 | `refactor` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9 |
+| 14 | `feat` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/10 |
+| 15 | `docs` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/11 |
+| 16 | `chore` | https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/12 |
+
 ### Pricing / returns / fee-revenue
 
-5. **Parametrized fee capture** \(\pi^\phi(r_\phi^e)\)
+5. **Parametrized fee capture** \(\pi^\phi(r_\phi^e)\) — `feat` — [#1](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/1)
    - \((1-r_\phi^e)\,\phi_X P + r_\phi^e\,\phi_M I\)
    - Construct \(r_\phi^e = \phi\cdot r^e\) with \(\phi=\phi_M\otimes\phi_X\) (`toFeePips`)
    - Wire like Swap mixture; keep base `TransactionalFeeCapture` as \(r_\phi^e\)-free legs
 
-6. **`ExpectedReturn` composition / nonzero \(r(0)\)**
+6. **`ExpectedReturn` composition / nonzero \(r(0)\)** — `feat` — [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2)
    - `ExpectedReturn <>` Realized (and other expecteds) → that sum *is* future \(r(0)\) before κ-scaling
    - FeePips path today is through-origin (\(r=\kappa\phi\)); VISIBLE NOTE in `Pricing.ExpectedReturn`
 
-7. **Ref transactional return** \(r^\phi=\phi\,\delta_{\mathrm{trans}}\)
+7. **Ref transactional return** \(r^\phi=\phi\,\delta_{\mathrm{trans}}\) — `feat` — [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3)
    - Distinct from payoff \(\pi^\phi\); scope in `refs/VOLATILITY_INTRUMENTS_MEV.md`
    - Decide: scalar control return type vs leave in notes only
 
-8. **`MarkUpStructure` superclass; `FeeStructure` as instance**
+8. **`MarkUpStructure` superclass; `FeeStructure` as instance** — `feat` — [#4](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/4)
    - `FeeStructure` today is a concrete bag `{φ_X, φ_M}`
    - Introduce a class (name pin: `MarkUpStructure`) that abstracts markup bags; `FeeStructure` implements it
    - Goal: other markup shapes (one-sided, adaptive Θ-driven, …) share `ReturnFromKappa` / capture constructors without hard-wiring `FeeStructure`
    - Brainstorm before implement (typeclass vs data family vs newtype hierarchy)
 
-9. **`AdaptiveStremia` body** — still stub \(\phi(\Theta_\phi;\sigma^2,\nu)\)
+9. **`AdaptiveStremia` body** — `feat` — [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) — still stub \(\phi(\Theta_\phi;\sigma^2,\nu)\)
 
 ### Package / tree moves (README `//` notes; not done)
 
-10. **`Panoptic/` package** — move `NId.hs`, `MintPlan.hs` (and dependents as needed) out of `Payoffs/`
+10. **`Panoptic/` package** — `refactor` — [#6](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/6) — move `NId.hs`, `MintPlan.hs` out of `Payoffs/`
 
-11. **`Plotting/` package** — move `PlotSqrt.hs`, `PlotInterest.hs`, `PlotUtils.hs` out of `Payoffs/` / root
+11. **`Plotting/` package** — `refactor` — [#7](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/7) — move `PlotSqrt.hs`, `PlotInterest.hs`, `PlotUtils.hs`
 
-12. **Rename** `CPMMPosition` → `CLMMPosition`
+12. **Rename** `CPMMPosition` → `CLMMPosition` — `refactor` — [#8](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/8)
 
-13. **`TargetVega`** — move out of `Payoffs/` (README: outside)
+13. **`TargetVega`** — `refactor` — [#9](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9) — move out of `Payoffs/`
 
 ### Liquidity / density (pre-existing)
 
-14. **Chunk × density EVM mul** (Bunni/Panoptic) — `LiquidityDensity` / `TickLiquidity` TODOs; geometric \(L\) only so far
+14. **Chunk × density EVM mul** — `feat` — [#10](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/10)
 
-15. **Density → Panoptic `optionRatio` brainstorm** — see `docs/superpowers/specs/2026-08-20-liquiditydensity-optionratio-brainstorm.md`
+15. **Density → Panoptic `optionRatio` brainstorm** — `docs` — [#11](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/11)
 
 ### Hygiene
 
-16. **Commit / PR** scratchpad WIP on `main` (κ C, ExpectedReturn, TransactionalFeeCapture, README tree, `refs/`, this TODO) when ready — currently uncommitted
+16. **Commit / PR** scratchpad WIP — `chore` — [#12](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/12)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MonoLocalBinds #-}
 
 module Main (main) where
 
@@ -93,6 +95,11 @@ import Volatility.CevField
 import Volatility.VolTermStructure (BarL(..), FlowVol(..), cevFromPhi)
 import StrikeX96 (strike)
 
+-- Avoid DuplicateRecordFields update/selector ambiguity with InterestPlot.
+retitleSqrt :: SqrtPlot -> String -> String -> SqrtPlot
+retitleSqrt (SqrtPlot _ xa _ xmin xmax) title ya =
+  SqrtPlot title xa ya xmin xmax
+
 main :: IO ()
 main = do
   createDirectoryIfMissing True "outputs/Pricing"
@@ -135,10 +142,9 @@ main = do
 
   plotSqrtFunction
     "outputs/Payoffs/Returns/stremia-bid-ask.png"
-    config
-      { plotTitle = "mid / ask/bid ReturnPips (FeePips 100 & 3000)"
-      , yAxisTitle = "ReturnPips"
-      }
+    (retitleSqrt config
+      "mid / ask/bid ReturnPips (FeePips 100 & 3000)"
+      "ReturnPips")
     ReturnY
     [ linearPayoff
     , nakedAskQ96 (mkFeePips 100)
@@ -179,10 +185,9 @@ main = do
     tHi = mkInterestTick 100
   plotSqrtFunction
     "outputs/Payoffs/swap-pay-linear-vs-sqrtPriceX96.png"
-    config
-      { plotTitle = "Swap pay: linear×(1-φ_X) (φ_X=100)"
-      , yAxisTitle = "PayoffX96"
-      }
+    (retitleSqrt config
+      "Swap pay: linear×(1-φ_X) (φ_X=100)"
+      "PayoffX96")
     PayoffY
     [Payoff.runPayoff payPf]
   plotInterestFunction
@@ -215,10 +220,9 @@ main = do
     TransactionalFeeCapture (Leg capPayPf) (Leg capRecvPf) = fcDemo
   plotSqrtFunction
     "outputs/Payoffs/fee-capture-pay-vs-sqrtPriceX96.png"
-    config
-      { plotTitle = "Fee capture pay: linear×φ_X (φ_X=100)"
-      , yAxisTitle = "PayoffX96"
-      }
+    (retitleSqrt config
+      "Fee capture pay: linear×φ_X (φ_X=100)"
+      "PayoffX96")
     PayoffY
     [Payoff.runPayoff capPayPf]
   plotInterestFunction

--- a/cfmm-scratchpad.cabal
+++ b/cfmm-scratchpad.cabal
@@ -119,7 +119,7 @@ test-suite cfmm-scratchpad-test
       Paths_cfmm_scratchpad
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N -Wno-name-shadowing -Wno-type-defaults -Wno-gadt-mono-local-binds
   build-depends:
       Chart
     , Chart-cairo

--- a/package.yaml
+++ b/package.yaml
@@ -61,5 +61,9 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    # Spec is one long IO script; pedantic CI would drown in shadowing/defaulting.
+    - -Wno-name-shadowing
+    - -Wno-type-defaults
+    - -Wno-gadt-mono-local-binds
     dependencies:
     - cfmm-scratchpad

--- a/src/Payoffs/NId.hs
+++ b/src/Payoffs/NId.hs
@@ -212,9 +212,9 @@ addWidth tid width leg =
 addLegFromBucket :: Integer -> Integer -> Integer -> Integer -> Integer -> Integer
 addLegFromBucket tid lo hi ts leg =
   let
-    span = hi - lo
-    strike = lo + span `div` 2
-    width = span `div` ts
+    tickSpan = hi - lo
+    strike = lo + tickSpan `div` 2
+    width = tickSpan `div` ts
   in
     addWidth (addStrike tid strike leg) width leg
 

--- a/src/Payoffs/TransactionalFeeCapture.hs
+++ b/src/Payoffs/TransactionalFeeCapture.hs
@@ -7,7 +7,9 @@ module Payoffs.TransactionalFeeCapture
   ( TransactionalFeeCapture(..)
   , feeFactorX96
   , transactionalFeeCaptureFromFeeStructure
+  , feeRevenueExpectedReturn
   , runFeeCaptureAlongTenor
+  , runFeeCaptureAlongTenorMixture
   , payPartitionErrorX96
   , recvPartitionErrorX96
   , assertAccountingIdentityWithSwap
@@ -20,20 +22,23 @@ import Payoffs.Swap
   ( Leg(..)
   , Side(..)
   , Swap(..)
+  , expectedReturnWeightX96
   , scalePayoffX96
   , swapFromFeeStructure
   )
-import Pricing.FeeStructure (FeeStructure(..))
+import Pricing.ExpectedReturn (ExpectedReturn(..), unExpectedReturn)
+import Pricing.FeeStructure (FeeStructure(..), toFeePips)
 import Pricing.InterestPriceMap (InterestPriceMap, priceTickAt)
 import Pricing.InterestSqrt
   ( InterestSqrtX96
   , InterestTick
   , interestSqrtX96
   )
-import Pricing.Stremia (FeePips(..), feePipsScale)
+import Pricing.Stremia (FeePips(..), feePipsScale, mkFeePips, unFeePips)
 import SqrtGrid
   ( PayoffX96(..)
   , SqrtPriceX96
+  , mulX96
   , pattern Q96
   , sqrtPriceX96
   )
@@ -59,6 +64,20 @@ transactionalFeeCaptureFromFeeStructure (FeeStructure φX φM) =
     (Leg $ Payoff $ \sr ->
         scalePayoffX96 (feeFactorX96 φM) (savingsPayoff sr))
 
+-- | \(r_\phi^e=\phi\cdot r^e\) with \(\phi=\phi_M\otimes\phi_X\).
+feeRevenueExpectedReturn
+  :: FeeStructure
+  -> ExpectedReturn
+  -> ExpectedReturn
+feeRevenueExpectedReturn fs re =
+  let
+    φ = toFeePips fs
+    r = unExpectedReturn re
+  in
+    ExpectedReturn $
+      mkFeePips $
+        (unFeePips φ * unFeePips r) `div` feePipsScale
+
 -- | \(Y=Y_{\mathrm{pay}}+Y_{\mathrm{recv}}\) along \(i=kt+i_0\).
 runFeeCaptureAlongTenor
   :: InterestPriceMap
@@ -72,6 +91,24 @@ runFeeCaptureAlongTenor ipm (TransactionalFeeCapture (Leg pay) (Leg recv)) t =
       runPayoff pay (sqrtPriceX96 (priceTickAt ipm t))
   in
     PayoffX96 (yp + yr)
+
+-- | \(\pi^\phi(r_\phi^e)\): \(Y=(1-w)Y_{\mathrm{pay}}+w\,Y_{\mathrm{recv}}\).
+-- Caller supplies \(r_\phi^e\) (e.g. via 'feeRevenueExpectedReturn').
+runFeeCaptureAlongTenorMixture
+  :: InterestPriceMap
+  -> ExpectedReturn
+  -> TransactionalFeeCapture 'Pay 'Receive SqrtPriceX96 InterestSqrtX96
+  -> InterestTick
+  -> PayoffX96
+runFeeCaptureAlongTenorMixture ipm rPhiE (TransactionalFeeCapture (Leg pay) (Leg recv)) t =
+  let
+    w = expectedReturnWeightX96 rPhiE
+    PayoffX96 yr = runPayoff recv (interestSqrtX96 t)
+    PayoffX96 yp =
+      runPayoff pay (sqrtPriceX96 (priceTickAt ipm t))
+    y = mulX96 yp (Q96 - w) + mulX96 yr w
+  in
+    PayoffX96 y
 
 -- | \(|Y_{\mathrm{capture}}+Y_{\mathrm{swap}}-Y_{\mathrm{linear}}|\).
 payPartitionErrorX96 :: FeeStructure -> SqrtPriceX96 -> Integer

--- a/src/Volatility/VolOrder.hs
+++ b/src/Volatility/VolOrder.hs
@@ -18,7 +18,7 @@ module Volatility.VolOrder
   ) where
 
 import Payoffs.TargetVega (TargetVega)
-import Payoffs.VolatilityCall (VolStrike(..), mkVolStrike, unVolStrike)
+import Payoffs.VolatilityCall (VolStrike, mkVolStrike, unVolStrike)
 import SqrtGrid
   ( SqrtPriceX96(..)
   , Tick

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -146,9 +146,11 @@ import Payoffs.TransactionalFeeCapture
   ( TransactionalFeeCapture(..)
   , assertAccountingIdentityWithSwap
   , feeFactorX96
+  , feeRevenueExpectedReturn
   , payPartitionErrorX96
   , recvPartitionErrorX96
   , runFeeCaptureAlongTenor
+  , runFeeCaptureAlongTenorMixture
   , transactionalFeeCaptureFromFeeStructure
   )
 import Pricing.InterestSqrt
@@ -1382,3 +1384,28 @@ main = do
     "fee capture along tenor ≡ sum"
     (PayoffX96 (ypCap + yrCap))
     (runFeeCaptureAlongTenor mapCap fcCap t0Cap)
+
+  -- π^φ(r_φ^e): feeRevenueExpectedReturn + mixture
+  let
+    reFullCap = ExpectedReturn (mkFeePips feePipsScale)
+    reZeroCap = ExpectedReturn (mkFeePips 0)
+    rPhiFull = feeRevenueExpectedReturn fsCap reFullCap
+    rPhiZero = feeRevenueExpectedReturn fsCap reZeroCap
+  assertEqual
+    "feeRevenueExpectedReturn r^e=0 → 0"
+    (mkFeePips 0)
+    (unExpectedReturn rPhiZero)
+  assertEqual
+    "feeRevenueExpectedReturn r^e=scale → φ"
+    (toFeePips fsCap)
+    (unExpectedReturn rPhiFull)
+  let
+    PayoffX96 yCapMix0 =
+      runFeeCaptureAlongTenorMixture mapCap rPhiZero fcCap t0Cap
+  assertEqual "fee capture mixture w=0 ≡ Y_pay" ypCap yCapMix0
+  let
+    -- Full weight on recv: use ExpectedReturn at feePipsScale as r_φ^e directly
+    rPhiAsWeight1 = ExpectedReturn (mkFeePips feePipsScale)
+    PayoffX96 yCapMix1 =
+      runFeeCaptureAlongTenorMixture mapCap rPhiAsWeight1 fcCap t0Cap
+  assertEqual "fee capture mixture w=1 ≡ Y_recv" yrCap yCapMix1


### PR DESCRIPTION
## Summary
- `feeRevenueExpectedReturn`: \(r_\phi^e=\phi\cdot r^e\) with \(\phi=\texttt{toFeePips}\)
- `runFeeCaptureAlongTenorMixture`: \((1-w)Y_{\mathrm{pay}}+w Y_{\mathrm{recv}}\) on fee-capture legs
- Tests for scale and w=0 / w=1; base sum path unchanged

## Linked issue
Solves #1

## Test plan
- [x] `stack test` green
- [x] feeRevenueExpectedReturn r^e=0 → 0; r^e=scale → φ
- [x] mixture w=0 ≡ Y_pay; w=1 ≡ Y_recv