### PR TITLE
refactor(todo-13): Move TargetVega out of Payoffs/

### DIFF
--- a/.github/todo-tracking/TODO-13.md
+++ b/.github/todo-tracking/TODO-13.md
@@ -2,6 +2,7 @@
 
 - **Type:** `refactor`
 - **Issue:** https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9
-- **Status:** open (tracking PR; implementation not started on this branch)
+- **PR:** https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/22
+- **Status:** done — top-level `TargetVega` (`src/TargetVega.hs`; was `Payoffs.TargetVega`)
 
-See `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (on `chore/todo-16-scratchpad-wip` / after merge) for the branch→issue→PR workflow.
+See `AGENTS.md` for the branch→issue→PR workflow.

--- a/.github/todo-tracking/TODO-13.md
+++ b/.github/todo-tracking/TODO-13.md
@@ -1,0 +1,7 @@
+# TODO.md #13
+
+- **Type:** `refactor`
+- **Issue:** https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9
+- **Status:** open (tracking PR; implementation not started on this branch)
+
+See `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (on `chore/todo-16-scratchpad-wip` / after merge) for the branch→issue→PR workflow.

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ src/
 │   ├── TransactionalFeeCapture.hs
 │   ├── PlotSqrt.hs      // → Plotting/ package
 │   ├── PlotInterest.hs  // → Plotting/ package
-│   ├── VariancePortfolio.hs
-│   └── TargetVega.hs    // → outside Payoffs/
+│   └── VariancePortfolio.hs
 ├── Pricing/
 │   ├── PriceDeformation.hs
 │   ├── Stremia.hs
@@ -144,6 +143,7 @@ src/
 ├── SqrtGrid.hs
 ├── StrikeX96.hs
 ├── OptionRatio.hs
+├── TargetVega.hs
 ├── PlotUtils.hs         // → Plotting/ package
 └── State.hs
 

--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,9 @@
 6. ~~**Rename** `CPMMPosition` → `CLMMPosition`~~ — `refactor` — [#8](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/8) / [#21](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/21)
    - Module `Payoffs.CLMMPosition`; `clmmEtaLayout`; plot series labels
 
+7. ~~**Move** `TargetVega` out of `Payoffs/`~~ — `refactor` — [#9](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9) / [#22](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/22)
+   - Top-level module `TargetVega` (`src/TargetVega.hs`)
+
 ---
 
 ## Open
@@ -33,7 +36,7 @@ We execute **least semantically impactful first**: renames and package moves bef
 | Exec | TODO | Why this wave |
 |------|------|----------------|
 | ~~1~~ | ~~**12**~~ | ~~Rename `CPMMPosition` → `CLMMPosition`~~ — **done** |
-| 2 | **13** | Move `TargetVega` out of `Payoffs/` — tree only |
+| ~~2~~ | ~~**13**~~ | ~~Move `TargetVega` out of `Payoffs/`~~ — **done** |
 | 3 | **10** | `Panoptic/` package move (`NId`, `MintPlan`) — tree only |
 | 4 | **11** | `Plotting/` package move — tree only |
 | 5 | **16** | Chore: land/PR scratchpad WIP so trees stay clean |
@@ -59,7 +62,6 @@ Later (after **19**+**21**, not numbered yet): compose \(r_{\Delta Q}^{e}\); wir
 | 9 | `feat` | [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) | [#18](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/18) | open | 9 |
 | 10 | `refactor` | [#6](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/6) | [#19](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/19) | open | 3 |
 | 11 | `refactor` | [#7](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/7) | [#20](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/20) | open | 4 |
-| 13 | `refactor` | [#9](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9) | [#22](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/22) | open | 2 |
 | 14 | `feat` | [#10](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/10) | [#23](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/23) | open | 8 |
 | 15 | `docs` | [#11](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/11) | [#24](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/24) | open | 7 |
 | 16 | `chore` | [#12](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/12) | [#13](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/13) | open | 5 |
@@ -134,13 +136,11 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 
-### Package / tree moves (README `//` notes; not done) — exec 2–4
+### Package / tree moves (README `//` notes; not done) — exec 3–4
 
 10. **`Panoptic/` package** — `refactor` — [#6](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/6) — move `NId.hs`, `MintPlan.hs` out of `Payoffs/` (exec 3)
 
 11. **`Plotting/` package** — `refactor` — [#7](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/7) — move `PlotSqrt.hs`, `PlotInterest.hs`, `PlotUtils.hs` (exec 4)
-
-13. **`TargetVega`** — `refactor` — [#9](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9) — move out of `Payoffs/` (exec 2)
 
 ### Liquidity / density (pre-existing) — exec 7–8
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -53,7 +53,7 @@ import Greeks.Gamma (gammaLayout, kristensenGammaLayoutVsGamma)
 import Payoffs.CLMMPosition (rhsPayoffLayout)
 import Payoffs.Forward (AtmForward(..))
 import Payoffs.NId (MintPlan(..), fourLegSkeleton, mkNId)
-import Payoffs.TargetVega (mkTargetVega, positionSizeForTargetVega)
+import TargetVega (mkTargetVega, positionSizeForTargetVega)
 import Liquidity.LiquidityChunk (createChunk)
 import Payoffs.VariancePortfolio
   ( variancePortfolioLayout

--- a/cfmm-scratchpad.cabal
+++ b/cfmm-scratchpad.cabal
@@ -50,7 +50,6 @@ library
       Payoffs.Return
       Payoffs.Savings
       Payoffs.Swap
-      Payoffs.TargetVega
       Payoffs.TransactionalFeeCapture
       Payoffs.VariancePortfolio
       Payoffs.VolatilityCall
@@ -65,6 +64,7 @@ library
       SqrtGrid
       State
       StrikeX96
+      TargetVega
       TickPath
       Trading.KappaCoordinate
       Trading.PriceImpact

--- a/src/Payoffs/MintPlan.hs
+++ b/src/Payoffs/MintPlan.hs
@@ -7,7 +7,7 @@ module Payoffs.MintPlan
 import Liquidity.LiquidityChunk (LiquidityChunk)
 
 -- EVM/Panoptic tokenId + SFPM positionSize. Split out of Payoffs.NId so that
--- Payoffs.TargetVega (needed by Volatility.VolOrder's targetVega field) can
+-- TargetVega (needed by Volatility.VolOrder's targetVega field) can
 -- depend on these shapes without creating a NId -> VolOrder -> TargetVega ->
 -- NId module cycle now that NId consumes VolOrder directly.
 

--- a/src/Payoffs/NId.hs
+++ b/src/Payoffs/NId.hs
@@ -21,7 +21,7 @@ module Payoffs.NId
 import Data.Bits (shiftL, shiftR, (.&.))
 import Liquidity.LiquidityChunk (createChunk)
 import Payoffs.MintPlan (MintPlan(..), PanopticTokenId(..), fourLegNumLegs)
-import Payoffs.TargetVega (mkTargetVega, unTargetVega)
+import TargetVega (mkTargetVega, unTargetVega)
 import Pricing.PriceDeformation (uniswapMaxTick, uniswapMinTick)
 import SqrtGrid (unTickSpacing)
 import Volatility.VolOrder
@@ -55,7 +55,7 @@ scaleByNId (NId n) x = (2 * x) `div` toInteger n
 -- Hop B: EVM/Panoptic tokenId + SFPM positionSize. ΔQ_v* is not in the id.
 -- Layout matches plank PanopticTokenId.plk (TokenId.sol offsets).
 -- PanopticTokenId / MintPlan / fourLegNumLegs live in Payoffs.MintPlan
--- (split out so Payoffs.TargetVega, needed by Volatility.VolOrder's
+-- (split out so TargetVega, needed by Volatility.VolOrder's
 -- targetVega field, does not import this module — avoids a
 -- NId → VolOrder → TargetVega → NId cycle).
 

--- a/src/Payoffs/VariancePortfolio.hs
+++ b/src/Payoffs/VariancePortfolio.hs
@@ -30,7 +30,7 @@ import Payoffs.Forward
   )
 import Payoffs.Log (logContract, nakedLogQ96)
 import Payoffs.NId (MintPlan, NId, scaleByNId)
-import Payoffs.TargetVega (TargetVega, targetVegaFromMint, unTargetVega)
+import TargetVega (TargetVega, targetVegaFromMint, unTargetVega)
 import SqrtGrid
   ( PayoffX96(..)
   , SqrtPriceX96(..)

--- a/src/TargetVega.hs
+++ b/src/TargetVega.hs
@@ -1,4 +1,4 @@
-module Payoffs.TargetVega
+module TargetVega
   ( TargetVega
   , mkTargetVega
   , unTargetVega
@@ -16,7 +16,7 @@ newtype TargetVega = TargetVega Integer
 mkTargetVega :: Integer -> TargetVega
 mkTargetVega v
   | v <= 0 =
-      error "Payoffs.TargetVega.mkTargetVega: ΔQ_v must be > 0"
+      error "TargetVega.mkTargetVega: ΔQ_v must be > 0"
   | otherwise = TargetVega v
 
 unTargetVega :: TargetVega -> Integer
@@ -32,15 +32,15 @@ u128Max = 2 ^ (128 :: Int) - 1
 targetVegaFromMint :: MintPlan -> TargetVega
 targetVegaFromMint plan
   | numLegs (mintTokenId plan) /= 4 =
-      error "Payoffs.TargetVega.targetVegaFromMint: num_legs must be 4"
+      error "TargetVega.targetVegaFromMint: num_legs must be 4"
   | chunkLiquidity (mintChunk plan) <= 0
       || chunkLiquidity (mintChunk plan) > u128Max =
-      error "Payoffs.TargetVega.targetVegaFromMint: chunk liquidity must fit uint128 and be > 0"
+      error "TargetVega.targetVegaFromMint: chunk liquidity must fit uint128 and be > 0"
   | otherwise = mkTargetVega (chunkLiquidity (mintChunk plan))
 
 targetVegaFromMints :: [MintPlan] -> TargetVega
 targetVegaFromMints [] =
-  error "Payoffs.TargetVega.targetVegaFromMints: need at least one mint"
+  error "TargetVega.targetVegaFromMints: need at least one mint"
 targetVegaFromMints ps =
   mkTargetVega $
     sum [ unTargetVega (targetVegaFromMint p) | p <- ps ]

--- a/src/Volatility/VolOrder.hs
+++ b/src/Volatility/VolOrder.hs
@@ -17,7 +17,7 @@ module Volatility.VolOrder
   , fixtureSymmetricVolOrder
   ) where
 
-import Payoffs.TargetVega (TargetVega)
+import TargetVega (TargetVega)
 import Payoffs.VolatilityCall (VolStrike, mkVolStrike, unVolStrike)
 import SqrtGrid
   ( SqrtPriceX96(..)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -51,7 +51,7 @@ import Payoffs.VariancePortfolio
   , variancePortfolioLayoutVsGamma
   , variancePortfolioLayoutVsXi
   )
-import Payoffs.TargetVega
+import TargetVega
   ( mkTargetVega
   , positionSizeForTargetVega
   , targetVegaFromMint


### PR DESCRIPTION
## Summary
- Moves `Payoffs.TargetVega` → top-level `TargetVega` (`src/TargetVega.hs`)
- Updates imports, cabal, README tree, TODO.md (exec 2 done)

## Linked issue
Closes #9

## Test plan
- [x] `stack build --pedantic`
- [x] `stack test`