### PR TITLE
docs: align README fee/return algebra and trim TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ src/
 │   ├── AdaptiveStremia.hs
 │   ├── FeeStructure.hs
 │   ├── ExpectedReturn.hs
+│   ├── DiscountFactor.hs   // planned (TODO #17): parametric m(·)
 │   ├── InterestSqrt.hs
 │   └── InterestPriceMap.hs
 ├── Trading/
@@ -225,162 +226,171 @@ Hop B atlas (two-sided ticks \(i\in[-160,150]\), \(\Delta=10\), \(\iota=32\); Y 
 
 
 
-Note from VOLATILITY_INSTRUMENTS.md 
+Note from VOLATILITY_INSTRUMENTS.md — canonical fee / return algebra (aligned with shipped code + `TODO.md` planned split).
 
-We have:
+### Stremia bid/ask (linear \(P\); sqrt via \(\sqrt{1+\phi}\))
 
 \[
-	\begin{aligned}
-		p_{\varphi}^{\text{(ask)}} \, &= (1+ \phi) p_{\varphi} \\
-		p_{\varphi}^{\text{(bid)}} \, &= \frac{p_{\varphi}}{1+\phi}
-	\end{aligned}
+p_{\varphi}^{(\mathrm{ask})} = (1+\phi)\,p_{\varphi},
+\qquad
+p_{\varphi}^{(\mathrm{bid})} = \frac{p_{\varphi}}{1+\phi}
 \]
 
+Atlas map: \(p_{\varphi} \to p_{1/2}\).
 
-And we have \(p_{\varphi} \to p_{1/2}\)
-
-Done: \(p_{1/2}^{(\mathrm{bid/ask})}\) —
+**Shipped** — \(p_{1/2}^{(\mathrm{bid/ask})}\):
 - payoffs: `Pricing.Stremia.nakedAskQ96` / `nakedBidQ96` (linear \(P\times(1+\phi)\))
 - quotes: `Trading.PriceImpact.askSqrtPriceX96` / `bidSqrtPriceX96` (\(s\sqrt{1+\phi}\))
 - `Trading.Quote`: mid+bid/ask `SqrtPriceX96` → \(\phi_M\leftarrow\phi(\mathrm{ask})\), \(\phi_X\leftarrow\phi(\mathrm{bid})\) (may differ)
 - equal-φ special case: `feePipsFromBidAsk mid bid ask` (agree ≤1 pip)
-- composite: `compositeFeePips φ_M φ_X` for \(\phi\equiv 1-(1-\phi_M)(1-\phi_X)\)
-- `Pricing.FeeStructure`: bag `{φ_X, φ_M}`; `toFeePips` → \(1-(1-\phi_M)(1-\phi_X)\)
-- `FeePips` is a `Monoid` (survival stack \(1-(1-\phi_1)(1-\phi_2)\)); `FeeStructure` is not
-- AdaptiveStremia stub: \(\phi(\Theta_\phi;\sigma^2,\nu)\)
-- Done: Def 45 `kappaAt (Maybe EtaX96) XiX96 LiquidityChunk` → `KappaCoordinate` / `KappaTick`
-  - `TickLiquidity` at chunk lo/hi (geometric \(L\); \(L_{\mathrm{hi}}/L_{\mathrm{lo}}=\xi\))
-  - `Nothing` η → `BASE_ETA` (½) ⇒ trading base \(1/\Delta\) on geometric book (Thm 43)
-  - **Encoding C (shipped):** `KappaTick` rung index on uniform lattice \(\kappa_j=j/N\), \(N=255\); Def 45 real κ then `snapKappaTick`
-  - **B retired:** `KappaPips` Word8 quantize removed
-- Done: `Pricing.ExpectedReturn` — `ReturnFromKappa` on `FeeStructure` \(((1-\kappa)\phi_X+\kappa\phi_M)\) and `FeePips` \((\kappa\phi,\,r(0)=0)\); `runSwapAlongTenorMixture` = \((1-w)Y_{\mathrm{pay}}+w Y_{\mathrm{recv}}\)
-- Done: `Payoffs.TransactionalFeeCapture` — \(\pi^\phi=\phi_X P+\phi_M I\); sum along tenor; accounting identity with Swap (capture+survival≡naked); plots `fee-capture-*-vs-*.png`
-- Done: `feeRevenueExpectedReturn` / `runFeeCaptureAlongTenorMixture` — \(\pi^\phi(r_\phi^e)\) with \(r_\phi^e=\phi\cdot r^e\)
-- **VISIBLE:** future `ExpectedReturn <>` Realized/other expecteds supplies \(r(0)\); ref \(r^\phi=\phi\,\delta_{\mathrm{trans}}\) still open
-- plot: `outputs/Payoffs/Returns/stremia-bid-ask.png` — mid + ask/bid `ReturnY`
-- plot: `outputs/Payoffs/Returns/stremia-fee-vs-return.png` — FeePips vs ReturnPips (ask / bid / \(r=\phi\))
-- plot: `outputs/Payoffs/Returns/stremia-fee-rate-vs-sqrt.png` — FeePips vs quote SqrtPriceX96 (bid left / ask right of mid)
+- plots: `outputs/Payoffs/Returns/stremia-bid-ask.png`, `stremia-fee-vs-return.png`, `stremia-fee-rate-vs-sqrt.png`
 
-Note:
-
-There is already \(\phi (\Theta_{\phi}; \sigma^2, \nu)\) the `AdaptiveStremia`
-
-And we have, given a `Quote` objetc wich containts this bid and ask:
+Given a `Quote` with bid/ask on \(p_{1/2}\):
 
 \[
-	\begin{aligned}
-		( \phi (p_{1/2}^{(\text{ask})}), \phi (p_{1/2}^{(\text{bid})}) )
-	\end{aligned}
+\bigl(\phi(p_{1/2}^{(\mathrm{ask})}),\;\phi(p_{1/2}^{(\mathrm{bid})})\bigr)
+\quad\Longrightarrow\quad
+\phi_M \leftarrow \phi(\mathrm{ask}),\;
+\phi_X \leftarrow \phi(\mathrm{bid})
 \]
 
-Then we do the assignment:
+Adaptive markup (stub): \(\phi(\Theta_\phi;\sigma^2,\nu)\) in `AdaptiveStremia`.
+
+### Fee bag (survival composite)
 
 \[
-	\begin{aligned}
-		\phi_M \leftarrow \phi (p_{1/2}^{(\text{ask})}) \\
-		\phi_X \leftarrow \phi (p_{1/2}^{(\text{bid})})
-	\end{aligned}
-\]
-
-Since we have the return coordinate \(r(\phi)\). Note that the curvature enters as the
-parameter:
-
-\[
-	\begin{aligned}
-		\phi \leftarrow \phi (\Theta_{\phi}; \sigma^2, \nu) \\
-		\phi \equiv 1 - (1 - \phi_M) (1 - \phi_X) \\
-		r (\kappa_{\varphi} ; \phi_X, \phi_M) = (1\, - \, \kappa_{\varphi}) \, \phi_M+ \kappa_{\varphi} \, \phi_X
-	\end{aligned}
-\]
-> **VISIBLE:** κ is a coordinate discretization like ticks (**encoding C shipped**): `KappaTick` / `KappaSpacing` (\(N=255\)). B (`KappaPips`) retired. `ExpectedReturn` / \(\pi^{\Delta Q}(r^e)\) mixture and `TransactionalFeeCapture` (base + \(\pi^\phi(r_\phi^e)\)) shipped; next return `<>` / ref \(r^\phi=\phi\delta_{\mathrm{trans}}\).
-
-Consider the expected return of the swap payoff :
-
-\[
-r^e_{\pi^{\Delta Q}}
-\equiv
-\mathbb E\left[m_{\Delta Q} \cdot \pi^{\Delta Q}\right],
+\mathrm{FeeStructure} = \{\phi_X,\phi_M\},
 \qquad
-P_{1/2},I(r_{1/2})<0
-
+\phi \equiv 1-(1-\phi_M)(1-\phi_X)
 \]
 
-Such taht it parametrizes the swap payoff:
+- `compositeFeePips` / `toFeePips` implement the survival composite above
+- `FeePips` is a `Monoid` (same survival stack); `FeeStructure` is not
+- **Planned** (`MarkUpStructure`, TODO #8): separate markup product fold \(\prod_i(1+m_i)\) — do **not** conflate with `toFeePips`
+
+### Swap survival legs
 
 \[
+\pi^{\Delta Q}_{\mathrm{pay}} = P_{1/2}(1-\phi_X),
+\qquad
+\pi^{\Delta Q}_{\mathrm{recv}} = I(r_{1/2})(1-\phi_M)
+\]
 
-\pi^{\Delta Q}(r^e_{\pi^{\Delta Q}};,\cdot)
+(`Payoffs.Swap.swapFromFeeStructure`; net along tenor: recv − pay.)
+
+### κ expected return (shipped)
+
+Lattice \(\kappa_j = j/N\), \(N=255\) — **encoding C**: `KappaTick` / `KappaSpacing`; B (`KappaPips`) retired. Def 45 `kappaAt (Maybe EtaX96) XiX96 LiquidityChunk` → `KappaCoordinate`.
+
+\[
+r(\kappa;\phi_X,\phi_M)
 =
+(1-\kappa)\,\phi_X + \kappa\,\phi_M
+\]
 
-(1-r^e_{\pi^{\Delta Q}}),
-P_{1/2}(1-\phi_X)
+Composite survival fee when needed: \(\phi \equiv 1-(1-\phi_M)(1-\phi_X)\) (`toFeePips`).
+
+
+| Index | Role | Expected return |
+|-------|------|-----------------|
+| \(m(\Delta Q)\) | swap / \(\Delta Q\) channel | \(r^e_{\pi^{\Delta Q}} \equiv \mathbb E[m(\Delta Q)\cdot \pi^{\Delta Q}]\) |
+| \(m(\phi,\Delta Q)\) | fee revenue via swap leg | \(\mathbb E[m(\phi,\Delta Q)\cdot \pi^{\Delta Q}]\) |
+| \(m(\phi)\) | fee revenue on \(\pi^\phi\) directly | \(r_\phi^e \equiv \mathbb E[m(\phi)\cdot \pi^\phi]\) |
+
+General price form (fee leg): \(\mathbb E^{\mathbb{Q}}[m\cdot \pi^{\varphi}]\) (see flow decomposition below).
+
+### Parametrized swap \(\pi^{\Delta Q}(r^e)\) (shipped mixture; measure TODO #17–#18)
+
+\[
+r^e_{\pi^{\Delta Q}} \equiv \mathbb E\!\left[m(\Delta Q)\cdot \pi^{\Delta Q}\right]
+\]
+
+\[
+\pi^{\Delta Q}(r^e;\cdot)
+=
+(1-r^e)\,P_{1/2}(1-\phi_X)
 +
-r^e_{\pi^{\Delta Q}},
-I(r_{1/2})(1-\phi_M)
-
+r^e\,I(r_{1/2})(1-\phi_M)
 \]
-
-Once a return is obtaianed from a payoff, we have that is parametrzied by the cruvature OR Ot moves on it. This calls for the kappa coordinate discretization as first class priority and such that the constructor of the payoff is parametric enough to allow for different constructions. In this case a return is obtaied from a FeeStructure:
 
 \[
-r(\kappa_\varphi;\phi_x,\phi_y)
+\pi^\phi(p_{1/2}, r_{1/2}; \phi_X, \phi_M)
 =
-
-(1-\kappa_\varphi)\phi_x
-+
-\kappa_\varphi\phi_y
+\phi_X P_{1/2} + \phi_M I(r_{1/2})
 \]
 
-Then the affine expression immediately below/right is (In this case the return takes a FeePips)
+(`Payoffs.TransactionalFeeCapture`; sum along tenor; accounting identity: capture + survival swap leg ≡ naked \(P\) / \(I\), ≤1 X96; plots `fee-capture-*-vs-*.png`.)
 
-\[
-r(\kappa_\varphi;\phi)
-=
-r(0)+\kappa_\varphi\phi
-\]
+### Parametrized fee capture \(\pi^\phi(r_\phi^e)\) (shipped mixture; full measure TODO #17–#18)
 
-Now consider the expected fee revenue return:
+With \(\phi = \texttt{toFeePips}(\{\phi_X,\phi_M\})\) (survival composite):
 
 \[
 r_\phi^e
 =
-\mathbb E\left[\phi\cdot\pi^{\Delta Q}\right] = \phi \cdot r^e_{\pi^{\Delta Q}}
+\mathbb E\!\left[m(\phi,\Delta Q)\cdot \pi^{\Delta Q}\right]
+\qquad\text{(via swap channel)}
 \]
 
-Considering \(\phi= \phi_M\otimes\phi_X\).
-
-Now we obtained the equivalent parametrized expected fee revenue as:
-
 \[
-\pi^\phi(r_\phi^e;,\cdot)
+r_\phi^e
 =
-(1-r_\phi^e),
-\phi_X P_{1/2}
+\mathbb E\!\left[m(\phi)\cdot \pi^\phi\right]
+\qquad\text{(direct fee-revenue payoff)}
+\]
+
+**Shipped shortcut** (scalar mixture weight, no `DiscountFactor` yet):
+
+\[
+r_\phi^e = \phi\cdot r^e_{\pi^{\Delta Q}}
+\]
+
+\[
+\pi^\phi(r_\phi^e;\cdot)
+=
+(1-r_\phi^e)\,\phi_X P_{1/2}
 +
-r_\phi^e,\cdot \phi_M I(r_{1/2})
+r_\phi^e\,\phi_M I(r_{1/2})
 \]
 
+(`feeRevenueExpectedReturn` / `runFeeCaptureAlongTenorMixture`.)
 
-We have:
+### Ref transactional return (open — TODO #7)
 
 \[
-	\begin{aligned}
-		\Delta Q \, &= \, \mathbb{I}_{\Delta Q} \, \Delta Q_X + (1 - \mathbb{I}_{\Delta Q}) \, \Delta Q_M
-	\end{aligned}
+r^\phi = \phi\,\delta_{\mathrm{trans}}
 \]
 
+Distinct from payoff \(\pi^\phi\). Use scratchpad \(r^\phi\) / \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) notation only — **not** MEV-doc \(\Delta\pi_{\mathrm{trans}}/\pi_{\mathrm{trans}}\) (wrong). See `refs/VOLATILITY_INTRUMENTS_MEV.md` for economics only.
 
-Then:
+### Expected return split (planned — TODO #17–#21; prereq for #6)
 
 \[
-	\begin{aligned}
-		\Delta \pi^{\phi} \,& = \, \phi (\Theta_{\phi}; \sigma^2, \nu) \, \cdot \, \Delta Q \\
-		\int_{N} \, \Delta \pi^{\phi} \, \Delta N \, &= \, \int_{N} \,  \Big (\phi (\Theta_{\phi}; \sigma^2, \nu) \, \cdot \, \Delta Q\Big) \, \cdot \Delta N \\
-		\frac{\Delta \pi^{\varphi}}{\Delta N} \leftarrow \int_{N} \, \Delta \pi^{\phi} \, \Delta N \\
-         \frac{\Delta \pi^{\varphi}}{\Delta N} \, \equiv p_{\pi^{\varphi}}\equiv \, \mathbb{E}^{\mathbb{Q}} \, \Big [m \cdot \pi^{\varphi}\Big]
-	\end{aligned}
+r_{\Delta Q}^{e}
+=
+r_{\Delta Q_{\mathrm{trans}}}^{e}
++
+\beta\cdot r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{IV},\sigma^{e})
 \]
 
+Measure: parametric \(m(\Delta Q)\), \(m(\phi,\Delta Q)\), \(m(\phi)\) via `DiscountFactor` / `Expectation` (TODO #17–#18). \(\sigma_{IV}\) stand-in: \(\sigma_{IV}(t)=2\phi\sqrt{V(t)/L(i(t))}\) (have `TickLiquidity`; no \(V(t)\) volume yet — u88 / ξ workaround TBD).
 
+### Flow decomposition and fee price
 
+\[
+\Delta Q = \mathbb{I}_{\Delta Q}\,\Delta Q_X + (1-\mathbb{I}_{\Delta Q})\,\Delta Q_M
+\]
+
+\[
+\begin{aligned}
+\Delta \pi^{\phi} &= \phi(\Theta_{\phi}; \sigma^2, \nu)\cdot \Delta Q \\
+\int_{N} \Delta \pi^{\phi}\,\Delta N
+&= \int_{N} \bigl(\phi(\Theta_{\phi}; \sigma^2, \nu)\cdot \Delta Q\bigr)\,\Delta N \\
+\frac{\Delta \pi^{\varphi}}{\Delta N}
+&\leftarrow \int_{N} \Delta \pi^{\phi}\,\Delta N \\
+\frac{\Delta \pi^{\varphi}}{\Delta N}
+&\equiv p_{\pi^{\varphi}}
+\equiv \mathbb{E}^{\mathbb{Q}}\!\left[m\cdot \pi^{\varphi}\right]
+\end{aligned}
+\]
 

--- a/TODO.md
+++ b/TODO.md
@@ -15,90 +15,53 @@
 5. ~~**Parametrized fee capture** \(\pi^\phi(r_\phi^e)\)~~ — `feat` — [#1](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/1) / [#14](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/14)
    - `feeRevenueExpectedReturn` (\(r_\phi^e=\phi\cdot r^e\)); `runFeeCaptureAlongTenorMixture`
 
-6. ~~**Rename** `CPMMPosition` → `CLMMPosition`~~ — `refactor` — [#8](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/8) / [#21](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/21)
-   - Module `Payoffs.CLMMPosition`; `clmmEtaLayout`; plot series labels
-
-7. ~~**Move** `TargetVega` out of `Payoffs/`~~ — `refactor` — [#9](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9) / [#22](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/22)
-   - Top-level module `TargetVega` (`src/TargetVega.hs`)
-
-8. ~~**`Panoptic/` package**~~ — `refactor` — [#6](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/6) / [#19](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/19)
-   - `Panoptic.NId`, `Panoptic.MintPlan` (`src/Panoptic/`)
-
-9. ~~**`Plotting/` package**~~ — `refactor` — [#7](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/7) / [#20](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/20)
-   - `Plotting.PlotSqrt`, `Plotting.PlotInterest`, `Plotting.PlotUtils` (`src/Plotting/`)
-
-10. ~~**Commit / PR** scratchpad WIP~~ — `chore` — [#12](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/12) / [#13](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/13)
-   - Agent workflow docs + TODO↔issue map landed; product WIP followed on later PRs
-
 ---
 
 ## Open
 
 Workflow: see `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (classify → branch → issue → PR → cross-comment).
 
-### Execution order (ascending semantic impact)
-
-**TODO numbers are stable IDs** (they match existing GitHub issues). They are **not** priority.
-
-We execute **least semantically impactful first**: renames and package moves before type/econ changes; new return/measure algebra last. `#6` stays blocked until `#17`–`#21` land.
-
-| Exec | TODO | Why this wave |
-|------|------|----------------|
-| ~~1~~ | ~~**12**~~ | ~~Rename `CPMMPosition` → `CLMMPosition`~~ — **done** |
-| ~~2~~ | ~~**13**~~ | ~~Move `TargetVega` out of `Payoffs/`~~ — **done** |
-| ~~3~~ | ~~**10**~~ | ~~`Panoptic/` package move (`NId`, `MintPlan`)~~ — **done** |
-| ~~4~~ | ~~**11**~~ | ~~`Plotting/` package move~~ — **done** |
-| ~~5~~ | ~~**16**~~ | ~~Chore: land/PR scratchpad WIP~~ — **done** |
-| 6 | **8** | `MarkUpStructure` / `FeeStructure` — **refactor** of markup bag API (no new return law) |
-| 7 | **15** | Docs brainstorm (density → `optionRatio`) — no code semantics |
-| 8 | **14** | Chunk × density EVM mul — local numeric feat |
-| 9 | **9** | `AdaptiveStremia` body — fills stub; still before measure/return stack |
-| 10 | **17** | `DiscountFactor` / \(m(\cdot)\) — new measure type |
-| 11 | **18** | `Expectation` constructors — depends on **17** |
-| 12 | **19** | Exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) (scratchpad notation only) |
-| 13 | **7** | Ref \(r^\phi=\phi\,\delta_{\mathrm{trans}}\) — align with **19**; same notation rule |
-| 14 | **20** | \(\sigma_{IV}\) stand-in (\(V(t)\) gap) |
-| 15 | **21** | Parametric \(r_{\Delta Q_{\mathrm{arb}}}^{e}\) (+ \(\beta\)) — depends on **20** |
-| — | **6** | **Blocked** until **17–21**; then `ExpectedReturn <>` / nonzero \(r(0)\) |
-
-Later (after **19**+**21**, not numbered yet): compose \(r_{\Delta Q}^{e}\); wire \(\pi^{\Delta Q}/\pi^{\phi}\); unblock **6**.
-
-| TODO | Type | Issue | PR | Status | Exec |
-|------|------|-------|-----|--------|------|
-| 6 | `feat` | [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2) | [#15](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/15) | **blocked** (prereqs 17–21) | — |
-| 7 | `feat` | [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3) | [#16](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/16) | open | 13 |
-| 8 | `refactor` | [#4](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/4) | [#17](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/17) | open | 6 |
-| 9 | `feat` | [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) | [#18](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/18) | open | 9 |
-| 14 | `feat` | [#10](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/10) | [#23](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/23) | open | 8 |
-| 15 | `docs` | [#11](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/11) | [#24](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/24) | open | 7 |
-| 17 | `feat` | — | — | open (no GitHub issue yet) | 10 |
-| 18 | `feat` | — | — | open (no GitHub issue yet) | 11 |
-| 19 | `feat` | — | — | open (no GitHub issue yet) | 12 |
-| 20 | `feat` | — | — | open (no GitHub issue yet) | 14 |
-| 21 | `docs`→`feat` | — | — | open (no GitHub issue yet) | 15 |
+| TODO | Type | Issue | PR | Status |
+|------|------|-------|-----|--------|
+| 6 | `feat` | [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2) | [#15](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/15) | **blocked** (prereqs 17–21) |
+| 7 | `feat` | [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3) | [#16](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/16) | open |
+| 8 | `feat` | [#4](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/4) | [#17](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/17) | open |
+| 9 | `feat` | [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) | [#18](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/18) | open |
+| 10 | `refactor` | [#6](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/6) | [#19](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/19) | open |
+| 11 | `refactor` | [#7](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/7) | [#20](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/20) | open |
+| 12 | `refactor` | [#8](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/8) | [#21](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/21) | open |
+| 13 | `refactor` | [#9](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9) | [#22](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/22) | open |
+| 14 | `feat` | [#10](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/10) | [#23](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/23) | open |
+| 15 | `docs` | [#11](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/11) | [#24](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/24) | open |
+| 16 | `chore` | [#12](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/12) | [#13](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/13) | open |
+| 17 | `feat` | — | — | open (no GitHub issue yet) |
+| 18 | `feat` | — | — | open (no GitHub issue yet) |
+| 19 | `feat` | — | — | open (no GitHub issue yet) |
+| 20 | `feat` | — | — | open (no GitHub issue yet) |
+| 21 | `docs`→`feat` | — | — | open (no GitHub issue yet) |
 
 ### Pricing / returns / fee-revenue
 
-6. **`ExpectedReturn` composition / nonzero \(r(0)\)** — `feat` — [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2) / [#15](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/15) — **BLOCKED / deferred** (exec —)
+6. **`ExpectedReturn` composition / nonzero \(r(0)\)** — `feat` — [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2) / [#15](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/15) — **BLOCKED / deferred**
    - Parked until measure / expectation / return-split prereqs (**#17–#21**) exist
    - Then: `ExpectedReturn <>` Realized (and other expecteds) → that sum *is* future \(r(0)\) before κ-scaling
    - FeePips path today is through-origin (\(r=\kappa\phi\)); VISIBLE NOTE in `Pricing.ExpectedReturn`
    - Do **not** implement #6 while brainstorming #17–#21
 
-7. **Ref transactional return** \(r^\phi=\phi\,\delta_{\mathrm{trans}}\) — `feat` — [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3) (exec 13)
+7. **Ref transactional return** \(r^\phi=\phi\,\delta_{\mathrm{trans}}\) — `feat` — [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3)
    - Distinct from payoff \(\pi^\phi\); scope in `refs/VOLATILITY_INTRUMENTS_MEV.md`
    - Decide: scalar control return type vs leave in notes only
    - **Notation:** keep scratchpad \(r^\phi\) / \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) language; do **not** adopt MEV-doc \(\Delta\pi_{\mathrm{trans}}/\pi_{\mathrm{trans}}\) labels (wrong)
-   - Run after / alongside **#19** (same exogenous-trans family)
 
-8. **`MarkUpStructure` superclass; `FeeStructure` as instance** — `refactor` — [#4](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/4) (exec 6)
+8. **`MarkUpStructure` superclass; `FeeStructure` as instance** — `feat` — [#4](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/4)
    - `FeeStructure` today is a concrete bag `{φ_X, φ_M}`
    - Introduce a class (name pin: `MarkUpStructure`) that abstracts markup bags; `FeeStructure` implements it
    - Goal: other markup shapes (one-sided, adaptive Θ-driven, …) share `ReturnFromKappa` / capture constructors without hard-wiring `FeeStructure`
-   - Low semantic impact: reshapes API, does **not** change return laws; brainstorm typeclass vs data family vs newtype hierarchy before implement
+   - Brainstorm before implement (typeclass vs data family vs newtype hierarchy)
 
-9. **`AdaptiveStremia` body** — `feat` — [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) — still stub \(\phi(\Theta_\phi;\sigma^2,\nu)\) (exec 9)
+9. **`AdaptiveStremia` body** — `feat` — [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) — still stub \(\phi(\Theta_\phi;\sigma^2,\nu)\)
 
+Yes, those issues matches the intention, but the numbered order that is as it is right now does not imply the hierarchy of importance and the hierarchy of importance is now defined as follows. We are choosing to implement the issues as they have less like semantic impact. For example, renames are less semantically impactful because for example, the fee structure to mark up structure is just refactoring code. And then we start like imposing an order of execution of the issues based on that
 ### Measure / expectation / \(r_{\Delta Q}^{e}\) split (README affine story; prereqs for #6)
 
 Canonical split (scratchpad README notation — **required**):
@@ -113,37 +76,51 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
 
 **Do not** rename these to MEV-doc \(\Delta\pi_{\mathrm{trans}}/\pi_{\mathrm{trans}}\) (or similar); that notation is wrong. MEV note may be cited for economics only.
 
-17. **`DiscountFactor` / measure \(m(\cdot)\)** — `feat` (exec 10)
+17. **`DiscountFactor` / measure \(m(\cdot)\)** — `feat`
    - Parametric type (README: `DiscountFactor.hs`); indexes \(\Delta Q\) and/or \(\phi\)
    - Feeds \(\mathbb E[m\cdot\pi]\) for swap and fee-revenue expected returns
    - No GitHub issue until this TODO is accepted / brainstormed
 
-18. **`Expectation` constructor types** — `feat` (exec 11)
+18. **`Expectation` constructor types** — `feat`
    - Typed \(\mathbb E[m\cdot\pi]\) object (not only hand-built mixture weights)
    - Depends on #17
    - No GitHub issue yet
 
-19. **Exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\)** — `feat` (exec 12)
+19. **Exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\)** — `feat`
    - **MUST** keep this symbol / spelling in code, tests, issues, and docs
    - Orthogonal to directional price moves; volatility-measured (arbs not directional)
    - Cite MEV note for motivation only — **never** adopt its \(\Delta\pi_{\mathrm{trans}}\) naming
    - Decide: first-class return type vs notes-only scalar control
    - No GitHub issue yet
 
-20. **\(\sigma_{IV}\) stand-in** — `feat` (exec 14)
+20. **\(\sigma_{IV}\) stand-in** — `feat`
    - Raw Kristensen: \(\sigma_{IV}(t)=2\phi\sqrt{V(t)/L(i(t))}\)
    - Have `TickLiquidity`; **no** \(V(t)\) volume yet — brainstorm: volume type, ξ/liquidity workaround, or fitted u88-dimensional parameter (\(88=24+64\))
    - No GitHub issue yet
 
-21. **Parametric \(r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{IV},\sigma^{e})\)** (+ scalar \(\beta\)) — `docs` then `feat` (exec 15)
+21. **Parametric \(r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{IV},\sigma^{e})\)** (+ scalar \(\beta\)) — `docs` then `feat`
    - Endogenous arb expected return; \(\sigma^{e}\) = private vol expectation
    - Depends on #20; brainstorm functional form before implement
    - No GitHub issue yet
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 
-### Liquidity / density (pre-existing) — exec 7–8
+### Package / tree moves (README `//` notes; not done)
 
-14. **Chunk × density EVM mul** — `feat` — [#10](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/10) (exec 8)
+10. **`Panoptic/` package** — `refactor` — [#6](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/6) — move `NId.hs`, `MintPlan.hs` out of `Payoffs/`
 
-15. **Density → Panoptic `optionRatio` brainstorm** — `docs` — [#11](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/11) (exec 7)
+11. **`Plotting/` package** — `refactor` — [#7](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/7) — move `PlotSqrt.hs`, `PlotInterest.hs`, `PlotUtils.hs`
+
+12. **Rename** `CPMMPosition` → `CLMMPosition` — `refactor` — [#8](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/8)
+
+13. **`TargetVega`** — `refactor` — [#9](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9) — move out of `Payoffs/`
+
+### Liquidity / density (pre-existing)
+
+14. **Chunk × density EVM mul** — `feat` — [#10](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/10)
+
+15. **Density → Panoptic `optionRatio` brainstorm** — `docs` — [#11](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/11)
+
+### Hygiene
+
+16. **Commit / PR** scratchpad WIP — `chore` — [#12](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/12)


### PR DESCRIPTION
## Summary
- Restructure VOLATILITY_INSTRUMENTS fee/return notes in README (aligned with shipped code + planned DiscountFactor)
- Trim completed refactor items from TODO and simplify open tracking

## Test plan
- [ ] Docs-only change; CI should pass on PR

Made with [Cursor](https://cursor.com)