### PR TITLE
feat(todo-21): ExpectedVolatility Slice 1 (σ^e stub + volGap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ r_\phi^e
 \]
 
 
-
 \(r^e_{\pi^{\Delta Q}} \equiv \mathbb E[m(\Delta Q)\cdot \pi^{\Delta Q}]\)
 \[
 r_{\Delta Q}^{e}
@@ -284,8 +283,7 @@ and realizations:
 	\end{aligned}
 \]
 
-Where \(\delta_{\text{trans}}\) is pinned as (spec `docs/superpowers/specs/2026-08-22-scratchpad-rarb-trans-flow-design.md`; TODO #23):
-
+Where:
 \[
 	\begin{aligned}
 		\delta_{\text{trans}} (t)\, &\equiv \frac{\nu_{\text{trans}}(t)}{\pi_{\text{trans}}^{\Delta Q}(t)},
@@ -296,10 +294,26 @@ Where \(\delta_{\text{trans}}\) is pinned as (spec `docs/superpowers/specs/2026-
 \(\nu_{\text{trans}}\) derived from `refs/volume_path.gms` (\(g=\nu_{\text{trans}}/V\)); \(\pi_{\text{trans}}^{\Delta Q}\) parametrized only by exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\).
 
 
+Payoff decomposition (spec `docs/superpowers/specs/2026-08-22-scratchpad-pi-varphi-lvr-decomposition-design.md`; TODO #24):
+
+\[
+\pi^{c|p} + \pi^{\mathrm{RAN}} \equiv \pi^{\varphi} \equiv \pi^{\phi} - \pi^{\mathrm{LVR}}
+\]
+
+\[
+\pi^{\phi}=\pi^{\phi}\!\bigl(\pi_{\mathrm{trans}}^{\Delta Q}(r_{\mathrm{trans}}^{e})\bigr),
+\qquad
+\pi^{\mathrm{LVR}}=\pi^{\mathrm{LVR}}\!\bigl(\pi_{\mathrm{arb}}^{\Delta Q}(r_{\mathrm{arb}}^{e})\bigr),
+\qquad
+\pi^{\varphi}=\pi^{\phi}-\pi^{\mathrm{LVR}}.
+\]
+
+\(\pi_{\mathrm{trans}}^{\Delta Q}\) exogenous (#19); \(\pi_{\mathrm{arb}}^{\Delta Q}\) from vol gap (#21). Returns: \(r^{\varphi}=r^{\phi}-r^{\mathrm{LVR}}\) (MEV \(\mathcal{N}_\pi\)).
+
+**Roles:** GAMS \(\{\Delta Q_X,\Delta Q_M,\Delta s\}\) are **path utilities** to hit \(\delta_{\mathrm{trans}}^\*/r^{\phi}\); arb targets \(\sigma_{\mathrm{IV}}-\sigma^{e}\). Net CLMM/CPMM \(\pi^{\varphi}=f(\pi^{\phi}(\pi_{\mathrm{trans}})-\pi^{\mathrm{LVR}}(\pi_{\mathrm{arb}}))\). Roadmap: `docs/superpowers/specs/2026-08-22-scratchpad-channel-roles-roadmap.md`.
 
 
-
-### Flow decomposition and fee price
+## Flow decomposition and fee price
 
 \[
 \Delta Q = \mathbb{I}_{\Delta Q}\,\Delta Q_X + (1-\mathbb{I}_{\Delta Q})\,\Delta Q_M

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ src/
 │   ├── VolatilityGrid.hs
 │   ├── VolTermStructure.hs
 │   ├── TickVolatility.hs
+│   ├── ExpectedVolatility.hs
+│   ├── ImpliedVolatility.hs   // σ_IV minimal (TODO #20 full u-map)
 │   └── CevField.hs
 ├── TickPath.hs
 ├── SqrtGrid.hs
@@ -372,7 +374,7 @@ r_{\Delta Q}^{e}
 r_{\Delta Q_{\mathrm{trans}}}^{e}
 +
 \beta\cdot r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{IV},\sigma^{e})
-\]
+\] (RARB)
 
 Measure: parametric \(m(\Delta Q)\), \(m(\phi,\Delta Q)\), \(m(\phi)\) via `DiscountFactor` / `Expectation` (TODO #17–#18).
 
@@ -401,6 +403,29 @@ Off-equilibrium \(V(t)\) is unobserved (rates-only model). Carry \(u(t)\); obser
 | T2 | u88 encodes same \(u\) | optional EVM packing |
 
 Arb leg: \(r_{\Delta Q_{\mathrm{arb}}}^{e}=g(\sigma_{\mathrm{IV}}-\sigma^{e})\) with weight \(\beta\) (TODO #21–#22). \(\sigma^{e}=\mathbb{E}^{\mathbb{Q}}[\bar\sigma_X]\) — `ExpectedVolatility` + `VolHorizon` (WINDOW default \| tenor-aligned); spec `docs/superpowers/specs/2026-08-22-scratchpad-expected-volatility-design.md`. See `cfmm-options/IMPLIED_VOLATILITY.md` for \(\Sigma=\sigma\times\sigma_{\mathrm{IV}}\).
+
+
+Now expectations allow us to parametrize swwap payoff and define payoff of transactional traders and arbitragurs from the **RARB** equation.
+
+Now we can connect to the realied return variables \(r^{\phi}\) wher from the imprted on refs/ module:
+
+The rate:
+
+\[
+	\begin{aligned}
+		r^{\phi} = \phi \cdot \delta_{\text{trans}}
+	\end{aligned}
+\]
+
+Where \(\delta_{\text{trans}}\) is now pinned dimensionally as:
+
+\[
+	\begin{aligned}
+		\delta_{\text{trans}} (t)\, &\equiv \Big [ \frac{u(t)}{\pi_{\text{trans}}^{\Delta Q}}\Big]
+	\end{aligned}
+\]
+
+**Shipped (Slice 1, TODO #21):** `Volatility.ExpectedVolatility` — `expectedVolatilityUniformTenor`, `expectedVolatilityWindowStub`, `VolHorizon`; `Volatility.ImpliedVolatility` (minimal newtype); `volGap`. Plan: `docs/superpowers/plans/2026-08-22-scratchpad-expected-volatility.md`.
 
 ### Flow decomposition and fee price
 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,6 @@ src/
 │   ├── VolatilityGrid.hs
 │   ├── VolTermStructure.hs
 │   ├── TickVolatility.hs
-│   ├── ExpectedVolatility.hs
-│   ├── ImpliedVolatility.hs   // σ_IV minimal (TODO #20 full u-map)
 │   └── CevField.hs
 ├── TickPath.hs
 ├── SqrtGrid.hs
@@ -156,164 +154,35 @@ src/
 outputs/{Pricing,Payoffs,Payoffs/Returns,Greeks,Liquidity,TickPath,Volatility}/
 ```
 
-> Tree lists **current** modules.
-
-- `Payoffs.Linear.linearPayoff`: standardized linear \(P=s^2\) as `PayoffX96`.
-- `Payoffs.Return.ReturnPips` / `mkReturn`: ppm return of one level vs another (`returnPipsScale = 10^6`).
-- `Plotting.PlotSqrt.PlotY`: `PayoffY` | `ReturnY` on sqrt-series plots; return PNGs under `outputs/Payoffs/Returns/`.
-- `SqrtGrid`: \(\lambda=1.0001\), `TickSpacing` \(\Delta_i\in[1,200]\)
-- `Pricing.InterestSqrt`: `InterestTick` / `InterestSqrtX96` — \(\lambda^{t/2}\) twin of price `Tick` / `SqrtPriceX96` (interest dimensions; \(1+r=\lambda^{t}\))
-- `Payoff u`: parametric underlying (`SqrtPriceX96` | `InterestSqrtX96`, …)
-- `Payoffs.Savings.savingsPayoff` / `savings`: \(Y=s_r^{2}=\lambda^{t}\); plot `outputs/Payoffs/savings-vs-interestSqrtX96.png`
-- `Payoffs.Swap`: Pay/Receive phantoms; `swapFromFeeStructure` → pay Linear×(1-φ_X) vs sqrt, receive Savings×(1-φ_M) vs interest; net along \(i=kt+i_0\) (`outputs/Payoffs/swap-*-vs-*.png`, `swap-net-vs-interestSqrtX96.png`)
-- `Payoffs.TransactionalFeeCapture`: \(\pi^\phi=\phi_X P+\phi_M I\); sum along tenor; identity with Swap; plots `fee-capture-*-vs-*.png`
-- `Pricing.InterestPriceMap`: \(i=k t+i_0\) (caller `i_0`, default `k=1`)
-- `LiquidityGrid`: \(\xi\) is the liquidity base (like \(\lambda\) for price). Canonical \(Y\) is Bunni `uint256 liquidityDensityX96` (Q96), the Haskell type `LiquidityDensityX96`. \(\iota\) is ladder length, not \(\eta\).
-- `VolatilityGrid`: \(\Gamma_{\varphi}(i)\) coordinate. Canonical field \(\pi_{\sigma}\) is unit-notional `VolatilityCall` on that X.
-- `VolTermStructure` / `TickPath` / `TickVolatility`: PricePaths layer (below).
-- `CevField`: static CEV \(\sigma(i)=\texttt{volAt}\,i=\delta/p_{1/2}(i)\), plotted under `outputs/Volatility/`.
-- `Greeks.Gamma`: Kristensen \(\partial^2V/\partial P^2\), not \(\Gamma_{\varphi}\). Interior \(-\Gamma\) vs `gammaCoordinate` is the tautological ray (`outputs/Greeks/vs-gammaCoordinate.png`).
-
-Main chooses which panels to write.
-
-Atlas rule: each folder has one canonical Y; `vs-*` only changes X.
-
-| Folder | Canonical Y | vs-xiCoordinate | vs-gammaCoordinate | vs-sqrtPriceX96 |
-|---|---|---|---|---|
-| Liquidity | `liquidityDensityX96` | done | done | done |
-| Payoffs (\(\pi_\sigma\)) | Algebra `(S−K)+` | done | done | done |
-| Volatility (CEV) | `volAt` = \(\delta/p_{1/2}(i)\) | done | done | done |
-
-vs-gamma for \(\pi_\sigma\): expected \(Y\propto(j+1)^2\) vs growing \(\Gamma_\varphi\) (visual floor is \(K=0\) scale, not a vanilla kink). \(Y\propto(\log\Gamma_\varphi)^2\).
-
-Do not plot `liquidityDensityX96` as a VolatilityCall Y (already the Liquidity atlas). \(\xi\) as X for \(\pi_\sigma\) is the decreasing dual of vs-gamma.
-
-CEV plots matter: they are the static \(\sigma(i)\) `VolTermStructure` was built for; B1 tick² is not that field. vs-sqrtPrice CEV is \(\sigma\propto 1/p\).
-
-Do not feed `volAt` into `VolatilityCall.payoff` (CEV return vol ≠ Algebra tick²).
-
-Liquidity density (`uint256 liquidityDensityX96`) is plotted against each atlas X, in this order:
-
-- `outputs/Liquidity/vs-xiCoordinate.png`
-- `outputs/Liquidity/vs-gammaCoordinate.png`
-- `outputs/Liquidity/vs-sqrtPriceX96.png`
-
-Tick path (this round):
-
-```
-cevFromPhi η L̄ σ_F → VolTermStructure → TickPath N seed i0 → ticks vs steps
-                                                      ↓
-                                              TickVolatility → σ_X
-```
-
-- \(T = N\), one step is one time unit; Algebra window is the whole path (`WINDOW := N`).
-- CES constructor is \((\eta, \bar L, \sigma_F)\) only. First inhabitant `BASE_ETA` (CPMM \(\beta=\eta=1/2\)). Maymin \(\delta = 2\sigma_F/\bar L\) is derived.
-- Four σ’s: \(\sigma_F\) = flow input; \(\sigma(i)\) = `volAt`; \(\sigma_X\) = Algebra window mean (`VolatilityAverage`); strike \(\sigma_K^2\) for the call is `VolStrike` (same Algebra raw integer as \(S\)).
-- MEV (\(P_{\mathrm{trade}}\), \(a_t\), …) maps **into** \(\sigma_F\) later (`flowVolFromMev`); not fields of `cevFromPhi`.
-- Plot: `outputs/TickPath/vs-steps.png` (Y = tick, X = steps).
-- Unit-notional \(\pi_\sigma=(S-K)^+\) (`Payoffs/VolatilityCall.hs`): \(S\) is `_volatilityOnRange` on the **static book** \(i\to i+\Delta_i\) (same rungs as Liquidity vs-gamma), not a CEV `TickPath`. \(K\) is Algebra-raw `VolStrike`. Plots: `outputs/Payoffs/vs-{gammaCoordinate,sqrtPriceX96,xiCoordinate}.png`.
-
-CEV field plots: `outputs/Volatility/vs-{sqrtPriceX96,gammaCoordinate,xiCoordinate}.png`.
-
-Hop A (money view): \(N_{\mathrm{id}}=2/N\), `Forward.hs` / `Log.hs` on linear \(P\) (`squareSqrtPrice`, never \(s-s^\star\)), opaque \(\Pi\) (`fromLegs` = `fromDef6` at ATM), then \(\pi_{96}=\Delta Q_v\cdot\Pi_{\mathrm{opt}}\). Plot: `outputs/Payoffs/variance-portfolio.png` (Y = `PayoffX96`, not clipped at 0). `targetVega` is raw \(L\), not a vol word.
-
-Hop B (in `NId.hs` / `MintPlan.hs`, under Hop A): EVM `PanopticTokenId` `{tokenId, numLegs}` + `MintPlan` `{mintTokenId, mintChunk :: LiquidityChunk}`. `PanopticTokenId` and `MintPlan` live in `Panoptic/MintPlan.hs` (split out of `NId.hs` so `TargetVega.hs` — needed by `Volatility/VolOrder.hs`'s `targetVega` field — does not import `NId`, avoiding a module cycle now that `NId` consumes `VolOrder` directly); `NId.hs` re-exports both. The 4-leg all-long tokenId is geometry-derived via `volOrderToTokenId :: VolOrder -> poolId -> ratios -> PanopticTokenId` (per-leg `optionRatio` 4-tuple in \(1..127\), puts below \(i^\star\), calls above; intervals and \(\Delta\) come from `legIntervals` / `tickBucketFromVolOrder`, not hardcoded ticks); `fourLegSkeleton` is now a thin wrapper calling `volOrderToTokenId` on `fixtureSymmetricVolOrder`. `volOrderToMintPlan` completes the `VolOrder → MintPlan` map: `mintChunk = createChunk i_l i_u (unTargetVega (volTargetVega vo))`, i.e. the envelope chunk at the order's `targetVega` (id is scale-free, including the ratio shape). Feasibility guards (each leg span \(\ge\Delta\); each side of \(i^\star\) \(\ge 2\Delta\)) `error` on infeasible `VolOrder`s. Dual-run: \(\pi_{96}\) from scalar \(\Delta Q_v\) equals \(\pi_{96}\) from `targetVegaFromMint`. The non-EVM `FourLegId` stub is gone. Hop C: `targetVegaFromMints` is additive. Not an on-chain `VolOrder` pack.
-
-`Volatility/VolOrder.hs`: Plank-faithful `VolOrder {volRangeWidth, volStrike, volSkew, volTargetVega}`. `tickBucketFromVolOrder` maps `volStrike` + `volSkew` + `volRangeWidth` → `(i_l, i_u, Δ)`; `legIntervals` splits that bucket at \(i^\star\) and the two midpoints into the four leg intervals `[i_l,m_p],[m_p,i^\star],[i^\star,m_c],[m_c,i_u]`. `fixtureSymmetricVolOrder` is the canonical symmetric fixture (\(\Delta=10\), \([-20,20]\) about tick 0).
-
-`Liquidity/LiquidityChunk.hs`: Panoptic `LiquidityChunk.sol` twin — opaque word packing `{tickLower, tickUpper, liquidity}` via `createChunk` / `chunkTickLower` / `chunkTickUpper` / `chunkLiquidity`. Not Bunni `LiquidityDensityX96`.
-
-Hop B atlas (two-sided ticks \(i\in[-160,150]\), \(\Delta=10\), \(\iota=32\); Y = `PayoffX96` from `MintPlan`, not Algebra `(S-K)+`): `outputs/Payoffs/variance-portfolio-vs-{gammaCoordinate,xiCoordinate}.png`. Does not overwrite `outputs/Payoffs/vs-*.png`.
-
-- Density→Panoptic ratio brainstorm (no implementation): [`docs/superpowers/specs/2026-08-20-liquiditydensity-optionratio-brainstorm.md`](../docs/superpowers/specs/2026-08-20-liquiditydensity-optionratio-brainstorm.md)
-
-
-
-Note from VOLATILITY_INSTRUMENTS.md — canonical fee / return algebra (aligned with shipped code + `TODO.md` planned split).
-
-### Stremia bid/ask (linear \(P\); sqrt via \(\sqrt{1+\phi}\))
-
 \[
-p_{\varphi}^{(\mathrm{ask})} = (1+\phi)\,p_{\varphi},
+p_{1/2}^{(\mathrm{ask})} = \sqrt{1+\phi} \,p_{1/2},
 \qquad
-p_{\varphi}^{(\mathrm{bid})} = \frac{p_{\varphi}}{1+\phi}
+p_{1/2}^{(\mathrm{bid})} = \frac{p_{1/2}}{\sqrt{1+\phi}}
 \]
-
-Atlas map: \(p_{\varphi} \to p_{1/2}\).
-
-**Shipped** — \(p_{1/2}^{(\mathrm{bid/ask})}\):
-- payoffs: `Pricing.Stremia.nakedAskQ96` / `nakedBidQ96` (linear \(P\times(1+\phi)\))
-- quotes: `Trading.PriceImpact.askSqrtPriceX96` / `bidSqrtPriceX96` (\(s\sqrt{1+\phi}\))
-- `Trading.Quote`: mid+bid/ask `SqrtPriceX96` → \(\phi_M\leftarrow\phi(\mathrm{ask})\), \(\phi_X\leftarrow\phi(\mathrm{bid})\) (may differ)
-- equal-φ special case: `feePipsFromBidAsk mid bid ask` (agree ≤1 pip)
-- plots: `outputs/Payoffs/Returns/stremia-bid-ask.png`, `stremia-fee-vs-return.png`, `stremia-fee-rate-vs-sqrt.png`
 
 Given a `Quote` with bid/ask on \(p_{1/2}\):
 
 \[
 \bigl(\phi(p_{1/2}^{(\mathrm{ask})}),\;\phi(p_{1/2}^{(\mathrm{bid})})\bigr)
 \quad\Longrightarrow\quad
-\phi_M \leftarrow \phi(\mathrm{ask}),\;
-\phi_X \leftarrow \phi(\mathrm{bid})
+\phi_M \leftarrow \phi(p_{1/2}^{(\mathrm{ask})}),\;
+\phi_X \leftarrow \phi(p_{1/2}^{(\mathrm{bid})})
 \]
 
-Adaptive markup (stub): \(\phi(\Theta_\phi;\sigma^2,\nu)\) in `AdaptiveStremia`.
+Under the fee rule:
 
-### Fee bag (survival composite)
 
 \[
-\mathrm{FeeStructure} = \{\phi_X,\phi_M\},
-\qquad
 \phi \equiv 1-(1-\phi_M)(1-\phi_X)
 \]
 
-- `Pricing.FeeStructure`: bag `{φ_X, φ_M}`; survival `toFeePips` → \(1-(1-\phi_M)(1-\phi_X)\)
-- `Pricing.MarkUpStructure`: markup bag class; `foldMarkUpFactor` = \(\prod_i(1+m_i)\); `TwoSidedMarkUp` exposes φ_X/φ_M; `FeeStructure` implements both; survival `toFeePips` unchanged
-- `FeePips` is a `Monoid` (same survival stack); `FeeStructure` is not
 
-### Swap survival legs
+And given adaptive markup (stub): \(\phi(\Theta_\phi;\sigma^2,\nu)\) in `AdaptiveStremia`.
 
 \[
-\pi^{\Delta Q}_{\mathrm{pay}} = P_{1/2}(1-\phi_X),
-\qquad
-\pi^{\Delta Q}_{\mathrm{recv}} = I(r_{1/2})(1-\phi_M)
-\]
-
-(`Payoffs.Swap.swapFromFeeStructure`; net along tenor: recv − pay.)
-
-### κ expected return (shipped)
-
-Lattice \(\kappa_j = j/N\), \(N=255\) — **encoding C**: `KappaTick` / `KappaSpacing`; B (`KappaPips`) retired. Def 45 `kappaAt (Maybe EtaX96) XiX96 LiquidityChunk` → `KappaCoordinate`.
-
-\[
-r(\kappa;\phi_X,\phi_M)
-=
-(1-\kappa)\,\phi_X + \kappa\,\phi_M
-\]
-
-Composite survival fee when needed: \(\phi \equiv 1-(1-\phi_M)(1-\phi_X)\) (`toFeePips`).
-
-
-| Index | Role | Expected return |
-|-------|------|-----------------|
-| \(m(\Delta Q)\) | swap / \(\Delta Q\) channel | \(r^e_{\pi^{\Delta Q}} \equiv \mathbb E[m(\Delta Q)\cdot \pi^{\Delta Q}]\) |
-| \(m(\phi,\Delta Q)\) | fee revenue via swap leg | \(\mathbb E[m(\phi,\Delta Q)\cdot \pi^{\Delta Q}]\) |
-| \(m(\phi)\) | fee revenue on \(\pi^\phi\) directly | \(r_\phi^e \equiv \mathbb E[m(\phi)\cdot \pi^\phi]\) |
-
-General price form (fee leg): \(\mathbb E^{\mathbb{Q}}[m\cdot \pi^{\varphi}]\) (see flow decomposition below).
-
-### Parametrized swap \(\pi^{\Delta Q}(r^e)\) (shipped mixture; measure TODO #17–#18)
-
-\[
-r^e_{\pi^{\Delta Q}} \equiv \mathbb E\!\left[m(\Delta Q)\cdot \pi^{\Delta Q}\right]
-\]
-
-\[
-\pi^{\Delta Q}(r^e;\cdot)
-=
-(1-r^e)\,P_{1/2}(1-\phi_X)
-+
-r^e\,I(r_{1/2})(1-\phi_M)
+	\begin{aligned}
+		\phi \leftarrow \phi(\Theta_\phi;\sigma^2,\nu)
+	\end{aligned}
 \]
 
 \[
@@ -321,12 +190,38 @@ r^e\,I(r_{1/2})(1-\phi_M)
 =
 \phi_X P_{1/2} + \phi_M I(r_{1/2})
 \]
+\[
+\pi^{\Delta Q}_{\mathrm{pay}} = P_{1/2}(1-\phi_X),
+\qquad
+\pi^{\Delta Q}_{\mathrm{recv}} = I(r_{1/2})(1-\phi_M)
+\]
 
-(`Payoffs.TransactionalFeeCapture`; sum along tenor; accounting identity: capture + survival swap leg ≡ naked \(P\) / \(I\), ≤1 X96; plots `fee-capture-*-vs-*.png`.)
+From where for any admissible expected return, it parametrizes the net-swap payoff:
 
-### Parametrized fee capture \(\pi^\phi(r_\phi^e)\) (shipped mixture; full measure TODO #17–#18)
+\[
+	\begin{aligned}
+        \pi^{\Delta Q}(r^e;\cdot)
+         &=  \, (1-r^e)\,\pi^{\Delta Q}_{\mathrm{pay}} \, + \, r^e\, \pi^{\Delta Q}_{\mathrm{recv}}\\
+		 \\
+        &= \, (1-r^e)\,P_{1/2}(1-\phi_X)
+        +
+        r^e\,I(r_{1/2})(1-\phi_M)
 
-With \(\phi = \texttt{toFeePips}(\{\phi_X,\phi_M\})\) (survival composite):
+	\end{aligned}
+\]
+
+
+\[
+\pi^\phi(r_\phi^e;\cdot)
+=
+(1-r_\phi^e)\,\phi_X P_{1/2}
++
+r_\phi^e\,\phi_M I(r_{1/2})
+\]
+
+
+where for returns we have expectations:
+
 
 \[
 r_\phi^e
@@ -342,74 +237,46 @@ r_\phi^e
 \qquad\text{(direct fee-revenue payoff)}
 \]
 
-**Shipped shortcut** (scalar mixture weight, no `DiscountFactor` yet):
 
-\[
-r_\phi^e = \phi\cdot r^e_{\pi^{\Delta Q}}
-\]
 
-\[
-\pi^\phi(r_\phi^e;\cdot)
-=
-(1-r_\phi^e)\,\phi_X P_{1/2}
-+
-r_\phi^e\,\phi_M I(r_{1/2})
-\]
-
-(`feeRevenueExpectedReturn` / `runFeeCaptureAlongTenorMixture`.)
-
-### Ref transactional return (open — TODO #7)
-
-\[
-r^\phi = \phi\,\delta_{\mathrm{trans}}
-\]
-
-Distinct from payoff \(\pi^\phi\). Use scratchpad \(r^\phi\) / \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) notation only — **not** MEV-doc \(\Delta\pi_{\mathrm{trans}}/\pi_{\mathrm{trans}}\) (wrong). See `refs/VOLATILITY_INTRUMENTS_MEV.md` for economics only.
-
-### Expected return split (planned — TODO #17–#21; prereq for #6)
-
+\(r^e_{\pi^{\Delta Q}} \equiv \mathbb E[m(\Delta Q)\cdot \pi^{\Delta Q}]\)
 \[
 r_{\Delta Q}^{e}
 =
 r_{\Delta Q_{\mathrm{trans}}}^{e}
 +
-\beta\cdot r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{IV},\sigma^{e})
+\partial_{(r_{\Delta Q_{\mathrm{trans}}}^{e}, r_{\Delta Q_{\mathrm{arb}}}^{e})}\cdot r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{IV} - \sigma^{e})
 \] (RARB)
 
-Measure: parametric \(m(\Delta Q)\), \(m(\phi,\Delta Q)\), \(m(\phi)\) via `DiscountFactor` / `Expectation` (TODO #17–#18).
+where:
 
-#### Implied vol without nominal \(V(t)\) (TODO #20 — spec `docs/superpowers/specs/2026-08-22-scratchpad-sigma-iv-latent-u-design.md`)
-
-Kristensen form with latent ratio \(u(t):=\ln(V(t)/L(i(t)))\):
+\(\sigma^{e}=\mathbb{E}^{\mathbb{Q}}[\sigma]\)
 
 \[
 \sigma_{\mathrm{IV}}(t)=2\phi\sqrt{V(t)/L(i(t))}=2\phi\,e^{u(t)/2}.
 \]
 
-Fair-fee **calibration pin** (equilibrium; `cfmm-discrete/STREAMING_PREMIUM.md` Eq 3.16):
 
 \[
-\sigma_X(t)=\sigma_{\mathrm{IV}}(t)
+\sigma \, (t)=\sigma_{\mathrm{IV}}(t)
 \iff
-u^\star(t)=2\ln\!\Big(\frac{\sigma_X(t)}{2\phi(\,;\sigma_X(t))}\Big).
+u^\star(t)=2\ln\!\Big(\frac{\sigma \, (t)}{2\phi(\,;\sigma \, (t))}\Big).
 \]
 
-Off-equilibrium \(V(t)\) is unobserved (rates-only model). Carry \(u(t)\); observables: `TickLiquidity` \(L\), fee \(\phi\), oracle \(\sigma_X\).
 
-| Tier | Update | Notes |
-|------|--------|-------|
-| T0 | \(u\leftarrow u^\star(\sigma_X,\phi)\) | default this cycle |
-| T1 | \(\Delta u\approx(\hat\epsilon_{V/L}-1)\,\Delta\ln L\) along tenor | \(\kappa_L\) liquidity growth — **not** fee-mix `KappaCoordinate` \(\kappa\) |
-| T2 | u88 encodes same \(u\) | optional EVM packing |
+geometry:
 
-Arb leg: \(r_{\Delta Q_{\mathrm{arb}}}^{e}=g(\sigma_{\mathrm{IV}}-\sigma^{e})\) with weight \(\beta\) (TODO #21–#22). \(\sigma^{e}=\mathbb{E}^{\mathbb{Q}}[\bar\sigma_X]\) — `ExpectedVolatility` + `VolHorizon` (WINDOW default \| tenor-aligned); spec `docs/superpowers/specs/2026-08-22-scratchpad-expected-volatility-design.md`. See `cfmm-options/IMPLIED_VOLATILITY.md` for \(\Sigma=\sigma\times\sigma_{\mathrm{IV}}\).
+Lattice \(\kappa_j = j/N\), \(N=255\) — **encoding C**: `KappaTick` / `KappaSpacing`; B (`KappaPips`) retired. Def 45 `kappaAt (Maybe EtaX96) XiX96 LiquidityChunk` → `KappaCoordinate`.
 
 
-Now expectations allow us to parametrize swwap payoff and define payoff of transactional traders and arbitragurs from the **RARB** equation.
+\[
+r^{\phi}(\kappa;\phi_X,\phi_M)
+=
+(1-\kappa)\,\phi_X + \kappa\,\phi_M
+\]
 
-Now we can connect to the realied return variables \(r^{\phi}\) wher from the imprted on refs/ module:
 
-The rate:
+and realizations:
 
 \[
 	\begin{aligned}
@@ -425,7 +292,9 @@ Where \(\delta_{\text{trans}}\) is now pinned dimensionally as:
 	\end{aligned}
 \]
 
-**Shipped (Slice 1, TODO #21):** `Volatility.ExpectedVolatility` — `expectedVolatilityUniformTenor`, `expectedVolatilityWindowStub`, `VolHorizon`; `Volatility.ImpliedVolatility` (minimal newtype); `volGap`. Plan: `docs/superpowers/plans/2026-08-22-scratchpad-expected-volatility.md`.
+
+
+
 
 ### Flow decomposition and fee price
 

--- a/README.md
+++ b/README.md
@@ -284,13 +284,16 @@ and realizations:
 	\end{aligned}
 \]
 
-Where \(\delta_{\text{trans}}\) is now pinned dimensionally as:
+Where \(\delta_{\text{trans}}\) is pinned as (spec `docs/superpowers/specs/2026-08-22-scratchpad-rarb-trans-flow-design.md`; TODO #23):
 
 \[
 	\begin{aligned}
-		\delta_{\text{trans}} (t)\, &\equiv \Big [ \frac{u(t)}{\pi_{\text{trans}}^{\Delta Q}}\Big]
+		\delta_{\text{trans}} (t)\, &\equiv \frac{\nu_{\text{trans}}(t)}{\pi_{\text{trans}}^{\Delta Q}(t)},
+		\qquad V(t)=L(i(t))\,e^{u(t)},\quad u=\ln(V/L)
 	\end{aligned}
 \]
+
+\(\nu_{\text{trans}}\) derived from `refs/volume_path.gms` (\(g=\nu_{\text{trans}}/V\)); \(\pi_{\text{trans}}^{\Delta Q}\) parametrized only by exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\).
 
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,6 +22,9 @@
 
 ## Open
 
+**Role roadmap (read first):** `docs/superpowers/specs/2026-08-22-scratchpad-channel-roles-roadmap.md`  
+— Lane A = trans targets via GAMS path utilities (\(\Delta Q,\Delta s\) transient); Lane B = arb via vol-spread; Lane C = \(\pi^{\varphi}=\pi^{\phi}-\pi^{\mathrm{LVR}}\). Issue numbers ≠ execution priority.
+
 Workflow: see `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (classify → branch → issue → PR → cross-comment).
 
 | TODO | Type | Issue | PR | Status |
@@ -43,6 +46,7 @@ Workflow: see `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (classify → branch → iss
 | 21 | `docs`→`feat` | [#31](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/31) | — | open |
 | 22 | `docs` | [#28](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/28) | — | open |
 | 23 | `feat` | [#34](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/34) | — | open |
+| 24 | `docs`→`feat` | [#35](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/35) | — | open |
 
 ### Pricing / returns / fee-revenue
 
@@ -117,6 +121,12 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - Golden table \(g(\delta^\*,\kappa,\bar\phi,\ldots)\) from GAMS grid (`make test-gams`); option A (exogenous \(\nu\)) **pre-prover stub only**
    - Prereq for #7 \(\delta_{\mathrm{trans}}=\nu_{\mathrm{trans}}/\pi_{\mathrm{trans}}^{\Delta Q}\) beyond stub; complements RARB Slice 1 (#19 trans tag)
    - Reads: `refs/volume_path.gms`, `refs/VOLUME_PATH.md`, `refs/MEV_TAX_MODEL_ONE_NOTES.md`
+
+24. **\(\pi^{\varphi}=\pi^{\phi}-\pi^{\mathrm{LVR}}\) decomposition** — `docs`→`feat` — [#35](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/35)
+   - Spec: `docs/superpowers/specs/2026-08-22-scratchpad-pi-varphi-lvr-decomposition-design.md`
+   - \(\pi^{c|p}+\pi^{\mathrm{RAN}}\equiv\pi^{\varphi}\) (CLMM); \(\pi^{\varphi}=\pi^{\phi}(\pi_{\mathrm{trans}}^{\Delta Q})-\pi^{\mathrm{LVR}}(\pi_{\mathrm{arb}}^{\Delta Q})\)
+   - \(\pi^{\mathrm{arb}}\equiv\pi_{\mathrm{arb}}^{\Delta Q}\) (#21); LVR = normalized return read off arb leg; \(r^{\varphi}=r^{\phi}-r^{\mathrm{LVR}}\)
+   - Depends: RARB trans tag (#19), arb mixture (#21); CLMM identity test vs `CLMMPosition`
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 

--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ Workflow: see `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (classify → branch → iss
 | 22 | `docs` | [#28](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/28) | — | open |
 | 23 | `feat` | [#34](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/34) | — | open |
 | 24 | `docs`→`feat` | [#35](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/35) | — | open |
+| 25 | `docs`→`feat` | [#36](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/36) | — | open |
 
 ### Pricing / returns / fee-revenue
 
@@ -127,6 +128,14 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - \(\pi^{c|p}+\pi^{\mathrm{RAN}}\equiv\pi^{\varphi}\) (CLMM); \(\pi^{\varphi}=\pi^{\phi}(\pi_{\mathrm{trans}}^{\Delta Q})-\pi^{\mathrm{LVR}}(\pi_{\mathrm{arb}}^{\Delta Q})\)
    - \(\pi^{\mathrm{arb}}\equiv\pi_{\mathrm{arb}}^{\Delta Q}\) (#21); LVR = normalized return read off arb leg; \(r^{\varphi}=r^{\phi}-r^{\mathrm{LVR}}\)
    - Depends: RARB trans tag (#19), arb mixture (#21); CLMM identity test vs `CLMMPosition`
+
+25. **\(\pi^{\sigma}=f(\pi^{\varphi})\) — Panoptic/Haskell bridge (not MEV Σ)** — `docs`→`feat` — [#36](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/36)
+   - **Ground truth:** shipped Hop A/B — \(\pi^{\sigma}=\Delta Q_{v}\cdot\Pi^{\sigma}_{\mathrm{opt}}\) with
+     \(\Pi^{\sigma}_{\mathrm{opt}}=N_{\mathrm{id}}\bigl((P-P^{\star})/P^{\star}-\ln(P/P^{\star})\bigr)+R\) (`VariancePortfolio` / `MintPlan` → `targetVegaFromMint`)
+   - **Open:** identify how \(\pi^{\varphi}\) (CLMM / fee−LVR, #24) enters \(\Pi_{\mathrm{opt}}\) / \(R\) / the book — board claim \(\pi^{\sigma}=f(\pi^{\varphi})\); MEV \(\sum L(i)\pi^{\varphi}(i)\) is **not** ground truth
+   - Spec pointer: `cfmm-theory/docs/superpowers/specs/2026-08-19-scratchpad-target-vega-replication-design.md` (≡^R OPEN); roadmap roles doc
+   - Depends: #24 (net \(\pi^{\varphi}\)); uses existing `VariancePortfolio` / `CLMMPosition`
+   - Deliverable: design note pinning \(f\) from Haskell; then code/tests if warranted
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 

--- a/TODO.md
+++ b/TODO.md
@@ -42,6 +42,7 @@ Workflow: see `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (classify → branch → iss
 | 20 | `feat` | — | — | open (no GitHub issue yet) |
 | 21 | `docs`→`feat` | [#31](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/31) | — | open |
 | 22 | `docs` | [#28](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/28) | — | open |
+| 23 | `feat` | [#34](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/34) | — | open |
 
 ### Pricing / returns / fee-revenue
 
@@ -108,6 +109,14 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - Brainstorm: what object is \(\beta\) (scalar weight? pool parameter? function of \(\kappa\)/\(\phi\)/liquidity?); units; bounds; who sets it; relation to measure \(m(\cdot)\) and \(\mathbb E[m\cdot\pi]\)
    - Deliverable: short design note (spec in `docs/superpowers/specs/`) before #21 implement; may stay notes-only if no code twin warranted this cycle
    - Prereq for composing full \(r_{\Delta Q}^{e}\) and unblocking #6
+
+23. **\(\nu_{\mathrm{trans}}\) from `volume_path.gms` (prover-native \(u\leftrightarrow\nu\))** — `feat` — [#34](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/34)
+   - Spec: `docs/superpowers/specs/2026-08-22-scratchpad-rarb-trans-flow-design.md` §3 (option **B** approved)
+   - Shock: \(V=\bar L e^u\), \(\delta^\*\) → `volTgtWad`, `txlVolumeRate`; \(u=\ln(V/\bar L)=\ln\kappa\) at prover boundary
+   - Derive \(\nu_{\mathrm{trans}}=\sum\sqrt{\bar p|\Delta Q_X\Delta Q_M|}\) from JSON `dQx`/`dQM`; \(g=\nu_{\mathrm{trans}}/V\)
+   - Golden table \(g(\delta^\*,\kappa,\bar\phi,\ldots)\) from GAMS grid (`make test-gams`); option A (exogenous \(\nu\)) **pre-prover stub only**
+   - Prereq for #7 \(\delta_{\mathrm{trans}}=\nu_{\mathrm{trans}}/\pi_{\mathrm{trans}}^{\Delta Q}\) beyond stub; complements RARB Slice 1 (#19 trans tag)
+   - Reads: `refs/volume_path.gms`, `refs/VOLUME_PATH.md`, `refs/MEV_TAX_MODEL_ONE_NOTES.md`
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 

--- a/cfmm-scratchpad.cabal
+++ b/cfmm-scratchpad.cabal
@@ -71,6 +71,8 @@ library
       Trading.PriceImpact
       Trading.Quote
       Volatility.CevField
+      Volatility.ExpectedVolatility
+      Volatility.ImpliedVolatility
       Volatility.TickVolatility
       Volatility.VolatilityGrid
       Volatility.VolOrder

--- a/docs/superpowers/plans/2026-08-22-scratchpad-expected-volatility.md
+++ b/docs/superpowers/plans/2026-08-22-scratchpad-expected-volatility.md
@@ -1,0 +1,394 @@
+# Scratchpad ExpectedVolatility σ^e — Slice 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Slice 1 of TODO #21 — typed `ExpectedVolatility` (oracle-integer units), uniform tenor stub, minimal `ImpliedVolatility` newtype for `volGap`, and tests; no `DiscountFactor` yet.
+
+**Architecture:** New `Volatility.ExpectedVolatility` holds σ^e newtypes, `VolHorizon` tag, tenor path builder over `InterestPriceMap`, and WINDOW identity stub. Minimal `Volatility.ImpliedVolatility` (newtype only — full u-map remains TODO #20) enables `volGap`. Tests in `test/Spec.hs` assert uniform tenor + gap algebra.
+
+**Tech Stack:** GHC via Stack (LTS 24.55), Haskell2010, `test/Spec.hs` IO asserts, `cfmm-scratchpad.cabal` exposed-modules.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-scratchpad-expected-volatility-design.md`
+
+## Global Constraints
+
+- Working directory: `/home/jmsbpp/learning/cfmm-theory/scratchpad`
+- Branch: `feat/todo-21-expected-volatility-slice1` (issue [#31](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/31))
+- σ^e and σ_X use **same integer units** as `VolatilityAverage` — not FeePips, not u88 sqrt trick
+- `OracleWindowHorizon` Slice 1 = **identity stub** from realized average (documented non-𝔼^Q placeholder)
+- `TenorHorizon` Slice 1 = **uniform** path — `averageVolatility` on `InterestPriceMap` tick ladder
+- Do **not** import or implement `DiscountFactor` / full `expectedVolatility :: DiscountFactor`
+- Minimal `ImpliedVolatility` newtype only; **no** `uStarFromCalibration` (TODO #20)
+- CI: `stack build --pedantic` + `stack test`
+- Commit only if the human asked; otherwise **skip every Commit step**
+
+---
+
+## File map
+
+| File | Role |
+|------|------|
+| `src/Volatility/ExpectedVolatility.hs` | **Create.** Types, tenor path, uniform + window stubs |
+| `src/Volatility/ImpliedVolatility.hs` | **Create.** Minimal newtype + `impliedVolatilityFromAverage` |
+| `cfmm-scratchpad.cabal` | Expose both modules |
+| `test/Spec.hs` | Slice 1 asserts |
+| `README.md` | One-line Slice 1 shipped note under σ^e paragraph |
+| `docs/superpowers/specs/2026-08-22-scratchpad-expected-volatility-design.md` | Status → `implementing` |
+
+---
+
+### Task 1: `Volatility.ExpectedVolatility` core types
+
+**Files:**
+- Create: `src/Volatility/ExpectedVolatility.hs`
+- Modify: `cfmm-scratchpad.cabal` (add `Volatility.ExpectedVolatility` after `Volatility.TickVolatility`)
+
+**Interfaces:**
+- Consumes: `VolatilityAverage`, `unVolatilityAverage` from `Volatility.TickVolatility`
+- Consumes: `InterestTick`, `unInterestTick`, `mkInterestTick` from `Pricing.InterestSqrt`
+- Produces:
+  - `ExpectedVolatility(..)`, `unExpectedVolatility`
+  - `RealizedVolatility(..)`, `unRealizedVolatility`
+  - `VolHorizon(..)` — `OracleWindowHorizon` | `TenorHorizon InterestTick`
+  - `realizedVolatilityFromAverage :: VolatilityAverage -> RealizedVolatility`
+  - `expectedVolatilityWindowStub :: VolatilityAverage -> ExpectedVolatility`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/Spec.hs` (after existing `averageVolatility` block ~L643):
+
+```haskell
+import Volatility.ExpectedVolatility
+  ( ExpectedVolatility(..)
+  , RealizedVolatility(..)
+  , VolHorizon(..)
+  , expectedVolatilityWindowStub
+  , realizedVolatilityFromAverage
+  , unExpectedVolatility
+  , unRealizedVolatility
+  )
+
+-- ExpectedVolatility Slice 1
+let volAvg0 = VolatilityAverage 0
+assertEqual
+  "realizedVolatilityFromAverage round-trip"
+  0
+  (unRealizedVolatility (realizedVolatilityFromAverage volAvg0))
+assertEqual
+  "expectedVolatilityWindowStub = realized (Slice 1 stub)"
+  0
+  (unExpectedVolatility (expectedVolatilityWindowStub volAvg0))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `stack test 2>&1 | tail -20`  
+Expected: FAIL — module `Volatility.ExpectedVolatility` not found
+
+- [ ] **Step 3: Write minimal implementation**
+
+```haskell
+module Volatility.ExpectedVolatility
+  ( ExpectedVolatility(..)
+  , unExpectedVolatility
+  , RealizedVolatility(..)
+  , unRealizedVolatility
+  , VolHorizon(..)
+  , realizedVolatilityFromAverage
+  , expectedVolatilityWindowStub
+  ) where
+
+import Pricing.InterestSqrt (InterestTick)
+import Volatility.TickVolatility (VolatilityAverage(..), unVolatilityAverage)
+
+-- | σ^e in Algebra oracle integer units (same as VolatilityAverage).
+newtype ExpectedVolatility = ExpectedVolatility Integer
+  deriving (Show, Eq)
+
+unExpectedVolatility :: ExpectedVolatility -> Integer
+unExpectedVolatility (ExpectedVolatility x) = x
+
+newtype RealizedVolatility = RealizedVolatility Integer
+  deriving (Show, Eq)
+
+unRealizedVolatility :: RealizedVolatility -> Integer
+unRealizedVolatility (RealizedVolatility x) = x
+
+data VolHorizon
+  = OracleWindowHorizon
+  | TenorHorizon InterestTick
+  deriving (Show, Eq)
+
+realizedVolatilityFromAverage :: VolatilityAverage -> RealizedVolatility
+realizedVolatilityFromAverage (VolatilityAverage x) = RealizedVolatility x
+
+-- VISIBLE NOTE: Slice 1 non-𝔼^Q stub — WINDOW ensemble deferred to Slice 3.
+expectedVolatilityWindowStub :: VolatilityAverage -> ExpectedVolatility
+expectedVolatilityWindowStub (VolatilityAverage x) = ExpectedVolatility x
+```
+
+Add `Volatility.ExpectedVolatility` to `cfmm-scratchpad.cabal` `exposed-modules`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `stack build --pedantic && stack test 2>&1 | tail -30`  
+Expected: PASS — new asserts `ok`
+
+- [ ] **Step 5: Commit** (skip unless human asked)
+
+---
+
+### Task 2: Uniform tenor `expectedVolatilityUniformTenor`
+
+**Files:**
+- Modify: `src/Volatility/ExpectedVolatility.hs`
+- Modify: `test/Spec.hs`
+
+**Interfaces:**
+- Consumes: `InterestPriceMap`, `priceTickAt`; `averageVolatility`, `TickPath`; `Data.Vector`
+- Produces:
+  - `expectedVolatilityUniformTenor :: InterestPriceMap -> InterestTick -> InterestTick -> ExpectedVolatility`
+  - `tenorTickPath :: InterestPriceMap -> InterestTick -> InterestTick -> TickPath` (exported for tests)
+
+- [ ] **Step 1: Write the failing test**
+
+```haskell
+import Pricing.InterestPriceMap (mkInterestPriceMap, priceTickAt)
+import TickPath (TickPath(..), pathLength, ticks)
+import Volatility.ExpectedVolatility (expectedVolatilityUniformTenor, tenorTickPath)
+
+let
+  ipmTen = mkInterestPriceMap 1 0
+  t0 = mkInterestTick 0
+  t7 = mkInterestTick 7
+  flatPath = TickPath 8 (V.replicate 8 0)
+  evFlat = expectedVolatilityUniformTenor ipmTen t0 t0
+  path07 = tenorTickPath ipmTen t0 t7
+assertEqual
+  "tenorTickPath t0→t7 length"
+  8
+  (pathLength path07)
+assertEqual
+  "tenorTickPath t0 tick"
+  0
+  (ticks path07 ! 0)
+assertEqual
+  "tenorTickPath t7 tick"
+  7
+  (ticks path07 ! 7)
+assertEqual
+  "uniform tenor flat t0=t0 ⇒ σ^e=0"
+  0
+  (unExpectedVolatility evFlat)
+assertEqual
+  "uniform tenor flat matches averageVolatility constant path"
+  (unVolatilityAverage (averageVolatility flatPath))
+  (unExpectedVolatility (expectedVolatilityUniformTenor ipmTen t0 t0))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `stack test 2>&1 | tail -20`  
+Expected: FAIL — `expectedVolatilityUniformTenor` not defined
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `ExpectedVolatility.hs`:
+
+```haskell
+import qualified Data.Vector as V
+import Pricing.InterestPriceMap (InterestPriceMap, priceTickAt)
+import Pricing.InterestSqrt (InterestTick, mkInterestTick, unInterestTick)
+import TickPath (TickPath(..))
+import Volatility.TickVolatility (averageVolatility, unVolatilityAverage)
+
+tenorTickPath :: InterestPriceMap -> InterestTick -> InterestTick -> TickPath
+tenorTickPath ipm t0 tR =
+  let
+    a = unInterestTick t0
+    b = unInterestTick tR
+    lo = min a b
+    hi = max a b
+    n = hi - lo + 1
+    vec =
+      V.generate n $ \j ->
+        priceTickAt ipm (mkInterestTick (lo + j))
+  in
+    -- averageVolatility needs ≥2 ticks; duplicate when degenerate
+    if n >= 2
+      then TickPath n vec
+      else
+        let ti = priceTickAt ipm t0
+        in TickPath 2 (V.replicate 2 ti)
+
+expectedVolatilityUniformTenor
+  :: InterestPriceMap
+  -> InterestTick
+  -> InterestTick
+  -> ExpectedVolatility
+expectedVolatilityUniformTenor ipm t0 tR =
+  ExpectedVolatility $
+    unVolatilityAverage (averageVolatility (tenorTickPath ipm t0 tR))
+```
+
+Update export list with `tenorTickPath`, `expectedVolatilityUniformTenor`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `stack build --pedantic && stack test 2>&1 | tail -30`  
+Expected: PASS
+
+- [ ] **Step 5: Commit** (skip unless human asked)
+
+---
+
+### Task 3: Minimal `ImpliedVolatility` + `volGap`
+
+**Files:**
+- Create: `src/Volatility/ImpliedVolatility.hs`
+- Modify: `src/Volatility/ExpectedVolatility.hs` (add `VolGap`, `volGap`)
+- Modify: `cfmm-scratchpad.cabal`
+- Modify: `test/Spec.hs`
+
+**Interfaces:**
+- Consumes: `ImpliedVolatility`, `impliedVolatilityFromAverage` from Task 3 module
+- Produces:
+  - `ImpliedVolatility(..)`, `unImpliedVolatility`, `impliedVolatilityFromAverage`
+  - `VolGap(..)`, `unVolGap`, `volGap :: ImpliedVolatility -> ExpectedVolatility -> VolGap`
+
+- [ ] **Step 1: Write the failing test**
+
+```haskell
+import Volatility.ImpliedVolatility
+  ( ImpliedVolatility(..)
+  , impliedVolatilityFromAverage
+  , unImpliedVolatility
+  )
+import Volatility.ExpectedVolatility (VolGap(..), unVolGap, volGap)
+
+let
+  iv = impliedVolatilityFromAverage (VolatilityAverage 100)
+  ev = ExpectedVolatility 40
+assertEqual
+  "volGap σ_IV − σ^e"
+  60
+  (unVolGap (volGap iv ev))
+assertEqual
+  "volGap zero when equal"
+  0
+  (unVolGap (volGap iv (ExpectedVolatility 100)))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `stack test 2>&1 | tail -20`  
+Expected: FAIL — `Volatility.ImpliedVolatility` or `volGap` missing
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/Volatility/ImpliedVolatility.hs`:
+
+```haskell
+module Volatility.ImpliedVolatility
+  ( ImpliedVolatility(..)
+  , unImpliedVolatility
+  , impliedVolatilityFromAverage
+  ) where
+
+import Volatility.TickVolatility (VolatilityAverage(..), unVolatilityAverage)
+
+-- | Kristensen σ_IV word (full u-map in TODO #20).
+newtype ImpliedVolatility = ImpliedVolatility Integer
+  deriving (Show, Eq)
+
+unImpliedVolatility :: ImpliedVolatility -> Integer
+unImpliedVolatility (ImpliedVolatility x) = x
+
+-- Slice 1 stand-in until uStarFromCalibration lands.
+impliedVolatilityFromAverage :: VolatilityAverage -> ImpliedVolatility
+impliedVolatilityFromAverage (VolatilityAverage x) = ImpliedVolatility x
+```
+
+Add to `ExpectedVolatility.hs`:
+
+```haskell
+import Volatility.ImpliedVolatility (ImpliedVolatility, unImpliedVolatility)
+
+newtype VolGap = VolGap Integer
+  deriving (Show, Eq)
+
+unVolGap :: VolGap -> Integer
+unVolGap (VolGap x) = x
+
+volGap :: ImpliedVolatility -> ExpectedVolatility -> VolGap
+volGap iv (ExpectedVolatility ev) =
+  VolGap (unImpliedVolatility iv - ev)
+```
+
+Expose `Volatility.ImpliedVolatility` in cabal; export `VolGap`, `volGap`, `unVolGap` from ExpectedVolatility.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `stack build --pedantic && stack test 2>&1 | tail -30`  
+Expected: PASS
+
+- [ ] **Step 5: Commit** (skip unless human asked)
+
+---
+
+### Task 4: Docs + spec status
+
+**Files:**
+- Modify: `README.md` (~σ^e paragraph)
+- Modify: `docs/superpowers/specs/2026-08-22-scratchpad-expected-volatility-design.md`
+
+**Interfaces:**
+- Produces: README bullet that Slice 1 modules are shipped; spec status `implementing` → `done` when PR merges
+
+- [ ] **Step 1: README note**
+
+Under σ^e spec link, add:
+
+```markdown
+- **Shipped (Slice 1):** `Volatility.ExpectedVolatility` (uniform tenor stub, WINDOW identity stub), `Volatility.ImpliedVolatility` (minimal newtype), `volGap`
+```
+
+- [ ] **Step 2: Spec status**
+
+Change header to:
+
+```markdown
+**Status:** done — plan `docs/superpowers/plans/2026-08-22-scratchpad-expected-volatility.md` (Slice 1)
+```
+
+- [ ] **Step 3: Final CI**
+
+Run: `stack build --pedantic && stack test`  
+Expected: PASS
+
+- [ ] **Step 4: Commit** (skip unless human asked)
+
+---
+
+## Self-review (plan vs spec)
+
+| Spec requirement | Task |
+|------------------|------|
+| `ExpectedVolatility` newtype (oracle int) | Task 1 |
+| `VolHorizon` WINDOW \| Tenor | Task 1 |
+| `RealizedVolatility` wrapper | Task 1 |
+| WINDOW stub (non-𝔼^Q Slice 1) | Task 1 |
+| `expectedVolatilityUniformTenor` | Task 2 |
+| `volGap` | Task 3 |
+| Minimal `ImpliedVolatility` | Task 3 |
+| Equilibrium pins (flat tenor, gap zero) | Tasks 2–3 tests |
+| No `DiscountFactor` | Global constraint |
+| u88 / full u-map | Out of scope |
+
+No placeholders in task steps. Type names consistent across tasks.
+
+---
+
+## Handoff
+
+After Slice 1 PR merges: update `TODO.md` #21 with PR URL; cross-comment issue #31. Slice 2 (mixture weights) and Slice 3 (full 𝔼^Q) are separate plans.

--- a/docs/superpowers/specs/2026-08-22-scratchpad-channel-roles-roadmap.md
+++ b/docs/superpowers/specs/2026-08-22-scratchpad-channel-roles-roadmap.md
@@ -112,15 +112,19 @@ r_{\Delta Q}^{e}
 
 Refactor / hygiene can interleave anytime (low semantic impact): **#10–#13, #16**.
 
-| Wave | Goal | TODOs |
-|------|------|-------|
-| **1 — Trans controls** | Parametrize \(\pi_{\mathrm{trans}}^{\Delta Q}\); keep GAMS as path prover | #19, then #7 stub |
-| **2 — Prover bridge** | Transients → \(\nu_{\mathrm{trans}}\), \(g\); pin \(\delta_{\mathrm{trans}}\) | #23 |
-| **3 — Vol / arb controls** | \(\sigma_{IV}\), \(\sigma^{e}\), gap → \(r_{\mathrm{arb}}^{e}\), \(\pi_{\mathrm{arb}}^{\Delta Q}\) | #20, #21 Slice 1–2, #22 |
-| **4 — Net \(\pi^{\varphi}\)** | Fee − LVR; CLMM check | #24 |
-| **5 — Measure + compose** | \(\mathbb{E}^{\mathbb{Q}}\); unblock #6 | #17, #18, #6 |
-| **Parallel** | Adaptive fee body consuming \(\nu\) | #9 (after #23 enough for \(\nu\)) |
-| **Side** | Liquidity / Panoptic density | #14, #15 |
+| Wave | Goal | TODOs | Start when |
+|------|------|-------|------------|
+| **0** | Merge in-flight σ^e Slice 1 + docs | PR [#33](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/33) / #21 Slice 1 | now |
+| **1 — Trans controls** | Parametrize \(\pi_{\mathrm{trans}}^{\Delta Q}\); GAMS stays path prover | **#19** (open issue), then **#7** stub [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3) | after Wave 0 |
+| **2 — Prover bridge** | Transients → \(\nu_{\mathrm{trans}}\), \(g\); pin \(\delta_{\mathrm{trans}}\) | **#23** [#34](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/34) | after #19 |
+| **3 — Vol / arb controls** | \(\sigma_{IV}\), \(\sigma^{e}\), gap → \(r_{\mathrm{arb}}^{e}\), \(\pi_{\mathrm{arb}}^{\Delta Q}\) | **#20**, **#21** feat, **#22** [#28](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/28) | after Wave 1 (can overlap Wave 2) |
+| **4 — Net \(\pi^{\varphi}\)** | Fee − LVR; CLMM check | **#24** [#35](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/35) | after #19 + #21 arb leg enough |
+| **5 — \(\pi^{\sigma}=f(\pi^{\varphi})\)** | Pin Panoptic \(f\) linking \(\Pi_{\mathrm{opt}}\) to \(\pi^{\varphi}\) | **#25** | after #24 |
+| **6 — Measure + compose** | \(\mathbb{E}^{\mathbb{Q}}\); unblock #6 | **#17**, **#18**, **#6** [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2) | after Waves 3–4 |
+| **Parallel** | Adaptive fee body consuming \(\nu\) | **#9** [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) | after #23 enough for \(\nu\) |
+| **Side** | Liquidity / Panoptic density | **#14**, **#15** | anytime |
+
+**First code issue to open and execute:** TODO **#19** (exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\)).
 
 ---
 
@@ -142,4 +146,5 @@ Refactor / hygiene can interleave anytime (low semantic impact): **#10–#13, #1
 > **GAMS invents swaps to hit \(\delta_{\mathrm{trans}}\) / \(r^{\phi}\).**  
 > **Arb invents returns to hit \(\sigma_{IV}-\sigma^{e}\).**  
 > **CLMM \(\pi^{\varphi}\) is fee(trans) − LVR(arb).**  
+> **\(\pi^{\sigma}=\Delta Q_{v}\cdot\Pi^{\sigma}_{\mathrm{opt}}\) (Panoptic); \(f(\pi^{\varphi})\) is open (#25).**  
 > **\(\Delta Q,\Delta s\) are never the story — targets and net \(\pi^{\varphi}\) are.**

--- a/docs/superpowers/specs/2026-08-22-scratchpad-channel-roles-roadmap.md
+++ b/docs/superpowers/specs/2026-08-22-scratchpad-channel-roles-roadmap.md
@@ -1,0 +1,145 @@
+# Scratchpad roadmap — roles, channels, issue map
+
+**Status:** living tracking doc (not an implementation plan)  
+**Date:** 2026-08-22  
+**Repo:** `cfmm-theory` / package `scratchpad/`
+
+**Purpose:** Keep the **role of each part** visible while issues ship out of order. Numbered TODOs are **not** execution priority; this doc is.
+
+---
+
+## Two inverse problems (do not conflate)
+
+### A — Transactional channel (GAMS / `volume_path`)
+
+**Targets (ends):** \(\delta_{\mathrm{trans}}^\*\), \(r^{\phi}=\phi\,\delta_{\mathrm{trans}}\), transactional payoffs \(\pi^{\phi}(\pi_{\mathrm{trans}}^{\Delta Q})\).
+
+**Transients (means):** \(\Delta s\), \(\Delta Q_X\), \(\Delta Q_M\), path nodes — **utilities only**. They exist to **realize** the targets; they are not the economic objects we parametrize in Haskell.
+
+```
+δ*_trans, r^φ*, V (volTgt)  →  volume_path.gms  →  {ΔQ_X(n), ΔQ_M(n)}
+                                      ↓
+                              ν_trans, π̄, g = ν_trans/V
+                                      ↓
+                    π_trans^ΔQ(r_trans^e) → π^φ → r^φ
+```
+
+**Role of GAMS:** inverse map from **desired rates / volume** to a **swap sequence**. Scratchpad consumes certified outputs (JSON, \(g\), \(\nu_{\mathrm{trans}}\)); it does not treat \(\Delta Q\) legs as first-class payoff parameters.
+
+| TODO | Issue | Role in lane A |
+|------|-------|----------------|
+| #23 | [#34](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/34) | Prover-native \(\nu_{\mathrm{trans}}\) / \(g\) from GAMS JSON |
+| #19 | — | Exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) → \(\pi_{\mathrm{trans}}^{\Delta Q}\) |
+| #7 | [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3) | \(r^{\phi}=\phi\,\delta_{\mathrm{trans}}\) (return, not \(\pi^{\phi}\)) |
+| #9 | [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) | \(\phi(\Theta;\sigma^2,\nu)\) — fee schedule **consumes** \(\nu\), not \(\Delta Q\) |
+
+Specs: `2026-08-22-scratchpad-rarb-trans-flow-design.md`; `refs/volume_path.gms`, `VOLUME_PATH.md`.
+
+---
+
+### B — Arbitrageur channel (vol-spread targets)
+
+**Targets (ends):** volatility spread \(\sigma_{\mathrm{IV}}-\sigma^{e}\); arb expected return \(r_{\Delta Q_{\mathrm{arb}}}^{e}\); arb payoff \(\pi_{\mathrm{arb}}^{\Delta Q}\); LVR read \(\pi^{\mathrm{LVR}}(\pi_{\mathrm{arb}}^{\Delta Q})\).
+
+**Contrary structure:** where A starts from \(\delta_{\mathrm{trans}}\) and **generates path**, B starts from **vol state / gap** and **parametrizes** arb return and arb swap payoff. Path geometry for arb (if needed later) is a **different** inverse problem — not `volume_path`’s \(\delta^\*\) shock.
+
+```
+σ_IV(u,φ), σ^e  →  VolGap  →  r_arb^e = g(VolGap)  →  π_arb^ΔQ
+                                                      ↓
+                                              π^LVR(π_arb^ΔQ)
+```
+
+| TODO | Issue | Role in lane B |
+|------|-------|----------------|
+| #20 | — | Latent \(u=\ln(V/L)\); \(\sigma_{\mathrm{IV}}=2\phi e^{u/2}\) |
+| #21 | [#31](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/31) | \(\sigma^{e}\), `volGap`, \(r_{\mathrm{arb}}^{e}\), \(\pi_{\mathrm{arb}}^{\Delta Q}\) |
+| #22 | [#28](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/28) | Weight \(\beta\) on arb leg in RARB return split |
+
+Specs: `2026-08-22-scratchpad-sigma-iv-latent-u-design.md`; `2026-08-22-scratchpad-expected-volatility-design.md`.
+
+---
+
+### C — Net contractual / CLMM position (composition)
+
+**Already shaped:** contractual volatility / CLMM geometry \(\pi^{c|p}+\pi^{\mathrm{RAN}}\) (`CLMMPosition`).
+
+**Realized net fee accrual:**
+
+\[
+\pi^{\varphi}
+=
+\pi^{\phi}\!\bigl(\pi_{\mathrm{trans}}^{\Delta Q}\bigr)
+-
+\pi^{\mathrm{LVR}}\!\bigl(\pi_{\mathrm{arb}}^{\Delta Q}\bigr)
+\;\equiv\;
+\pi^{c|p}+\pi^{\mathrm{RAN}}.
+\]
+
+So the position payoff is a **function of net fee revenue** = transactional fee revenue **minus** LVR read from the arb swap leg — not a third independent mixture.
+
+| TODO | Issue | Role in lane C |
+|------|-------|----------------|
+| #24 | [#35](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/35) | \(\pi^{\varphi}\) decomposition; LVR functional; CLMM identity |
+| #17–#18 | — | Measure \(m\), \(\mathbb{E}^{\mathbb{Q}}[m\cdot\pi^{\varphi}]\) |
+| #6 | [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2) | Compose returns → \(r(0)\); **blocked** until A+B returns exist |
+
+Spec: `2026-08-22-scratchpad-pi-varphi-lvr-decomposition-design.md`.
+
+---
+
+## RARB return split (controls, not path)
+
+\[
+r_{\Delta Q}^{e}
+=
+\underbrace{r_{\Delta Q_{\mathrm{trans}}}^{e}}_{\text{lane A control}}
++
+\beta\cdot
+\underbrace{r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{IV}-\sigma^{e})}_{\text{lane B control}}
+\]
+
+| Object | Lane | Transient? |
+|--------|------|------------|
+| \(\delta_{\mathrm{trans}}\), \(r^{\phi}\), \(\pi^{\phi}\) | A | No — targets / payoffs |
+| \(\{\Delta Q_X,\Delta Q_M,\Delta s\}\) | A | **Yes** — GAMS utilities |
+| \(\sigma_{IV},\sigma^{e},\mathrm{VolGap}\), \(r_{\mathrm{arb}}^{e}\), \(\pi_{\mathrm{arb}}^{\Delta Q}\) | B | No — targets / payoffs |
+| \(\pi^{\mathrm{LVR}}\), \(\pi^{\varphi}\) | C | No — derived / net |
+| \(\nu_{\mathrm{trans}}\) | A | Latent **intensity** from path; not a swap leg |
+
+---
+
+## Suggested execution waves (role-preserving)
+
+Refactor / hygiene can interleave anytime (low semantic impact): **#10–#13, #16**.
+
+| Wave | Goal | TODOs |
+|------|------|-------|
+| **1 — Trans controls** | Parametrize \(\pi_{\mathrm{trans}}^{\Delta Q}\); keep GAMS as path prover | #19, then #7 stub |
+| **2 — Prover bridge** | Transients → \(\nu_{\mathrm{trans}}\), \(g\); pin \(\delta_{\mathrm{trans}}\) | #23 |
+| **3 — Vol / arb controls** | \(\sigma_{IV}\), \(\sigma^{e}\), gap → \(r_{\mathrm{arb}}^{e}\), \(\pi_{\mathrm{arb}}^{\Delta Q}\) | #20, #21 Slice 1–2, #22 |
+| **4 — Net \(\pi^{\varphi}\)** | Fee − LVR; CLMM check | #24 |
+| **5 — Measure + compose** | \(\mathbb{E}^{\mathbb{Q}}\); unblock #6 | #17, #18, #6 |
+| **Parallel** | Adaptive fee body consuming \(\nu\) | #9 (after #23 enough for \(\nu\)) |
+| **Side** | Liquidity / Panoptic density | #14, #15 |
+
+---
+
+## Shipped anchors (do not re-litigate)
+
+| Piece | Status |
+|-------|--------|
+| \(\pi^{\phi}\) base + mixture | Done (#5 / PR #14) |
+| \(\pi^{\Delta Q}(r^e)\) mixture | Done |
+| `CLMMPosition` = call\|put + RAN | Done |
+| `MarkUpStructure` | Done |
+| \(\sigma^{e}\) Slice 1 stub | In flight (PR #33 / TODO #21) |
+| `volume_path.gms` prover | In `refs/` — **path utility**, not Haskell payoff |
+
+---
+
+## One-line memory aid
+
+> **GAMS invents swaps to hit \(\delta_{\mathrm{trans}}\) / \(r^{\phi}\).**  
+> **Arb invents returns to hit \(\sigma_{IV}-\sigma^{e}\).**  
+> **CLMM \(\pi^{\varphi}\) is fee(trans) − LVR(arb).**  
+> **\(\Delta Q,\Delta s\) are never the story — targets and net \(\pi^{\varphi}\) are.**

--- a/docs/superpowers/specs/2026-08-22-scratchpad-expected-volatility-design.md
+++ b/docs/superpowers/specs/2026-08-22-scratchpad-expected-volatility-design.md
@@ -1,6 +1,6 @@
 # Scratchpad ExpectedVolatility σ^e — design
 
-**Status:** draft — awaiting user review (plan TBD; TODO #21)  
+**Status:** done — plan `docs/superpowers/plans/2026-08-22-scratchpad-expected-volatility.md` (Slice 1)  
 **Date:** 2026-08-22  
 **Repo:** `cfmm-theory` / package `scratchpad/`  
 **Brainstorm:** σ^e as risk-neutral expectation of realized vol; dual horizon (WINDOW + tenor)  

--- a/docs/superpowers/specs/2026-08-22-scratchpad-pi-varphi-lvr-decomposition-design.md
+++ b/docs/superpowers/specs/2026-08-22-scratchpad-pi-varphi-lvr-decomposition-design.md
@@ -1,0 +1,175 @@
+# Scratchpad π^φ decomposition — π^φ, LVR, CLMM replication
+
+**Status:** approved — plan TBD; TODO #24  
+**Date:** 2026-08-22  
+**Repo:** `cfmm-theory` / package `scratchpad/`  
+**Brainstorm:** π^{c|p}+π^RAN ≡ π^φ ≡ π^φ−π^LVR; π^arb ≡ π_arb^ΔQ; parametrized π^φ  
+**Linked TODO:** #24; #7, #19, #21 (RARB legs), #17–#18 (measure)
+
+**Reads:** `scratchpad/README.md`; `Payoffs/CLMMPosition.hs`; `Payoffs/TransactionalFeeCapture.hs`; `Payoffs/Swap.hs`; `docs/superpowers/specs/2026-08-22-scratchpad-rarb-trans-flow-design.md`; `refs/VOLATILITY_INTRUMENTS_MEV.md` (Def 32, normalized returns)
+
+---
+
+## Purpose
+
+Establish the **payoff-level** decomposition linking:
+
+1. **CLMM geometry:** \(\pi^{c|p}+\pi^{\mathrm{RAN}}\equiv\pi^{\varphi}\)
+2. **Fee − LVR economics:** \(\pi^{\varphi}\equiv\pi^{\phi}-\pi^{\mathrm{LVR}}\)
+3. **Orthogonal parametrization:** trans vs arb swap legs (RARB), with \(\pi^{\mathrm{arb}}\equiv\pi_{\mathrm{arb}}^{\Delta Q}\)
+
+**Out of scope:** full `DiscountFactor` (#17), Milionis closed-form LVR beyond CPMM sanity check, on-chain twins.
+
+---
+
+## §1 — Identity chain (approved)
+
+\[
+\pi^{c|p} + \pi^{\mathrm{RAN}}
+\;\equiv\;
+\pi^{\varphi}
+\;\equiv\;
+\pi^{\phi} - \pi^{\mathrm{LVR}}.
+\]
+
+| Symbol | Meaning | Code |
+|--------|---------|------|
+| \(\pi^{c\|p}\) | Covered call **or** cash-secured put | `CoveredCall` / `CashSecuredPut` |
+| \(\pi^{\mathrm{RAN}}\) | Range accrual note (same strike) | `RangeAccrualNote` |
+| Sum | Single-tick CLMM LP | `CLMMPosition` |
+| \(\pi^{\phi}\) | Fee-revenue payoff | `TransactionalFeeCapture` |
+| \(\pi^{\mathrm{LVR}}\) | LVR / gamma leg (derived) | planned stub |
+| \(\pi^{\varphi}\) | Net LP accrual after LVR | compose |
+
+MEV state plant (Def 32): \(x\) includes \(\pi^{\phi}\) and \(\pi^{\phi}-\pi^{\mathrm{LVR}}\) (= \(\pi^{\varphi}\)).
+
+---
+
+## §2 — Functional tags (approved; π^arb = A)
+
+**Transactional channel** (exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) only):
+
+\[
+\pi^{\mathrm{trans}} \equiv \pi_{\mathrm{trans}}^{\Delta Q}(r_{\mathrm{trans}}^{e}),
+\qquad
+\pi^{\phi} = \pi^{\phi}\!\bigl(\pi^{\mathrm{trans}}\bigr)
+= \pi^{\phi}(r_\phi^e;\cdot).
+\]
+
+**Arb channel** (\(\pi^{\mathrm{arb}}\equiv\pi_{\mathrm{arb}}^{\Delta Q}\) — **not** a separate object):
+
+\[
+\pi_{\mathrm{arb}}^{\Delta Q}\!\bigl(r_{\mathrm{arb}}^{e}(\sigma_{IV}-\sigma^{e})\bigr),
+\qquad
+\pi^{\mathrm{LVR}} = \pi^{\mathrm{LVR}}\!\bigl(\pi_{\mathrm{arb}}^{\Delta Q}\bigr).
+\]
+
+**Net accrual (parametrized functional relation π^φ ↔ π_arb):**
+
+\[
+\boxed{
+\pi^{\varphi}\bigl(r_{\mathrm{trans}}^{e}, r_{\mathrm{arb}}^{e}\bigr)
+=
+\pi^{\phi}\!\bigl(\pi_{\mathrm{trans}}^{\Delta Q}(r_{\mathrm{trans}}^{e})\bigr)
+-
+\pi^{\mathrm{LVR}}\!\bigl(\pi_{\mathrm{arb}}^{\Delta Q}(r_{\mathrm{arb}}^{e})\bigr)
+}
+\]
+
+Subtractive composition: \(\pi^{\varphi}\) depends on arb **only** through \(\pi^{\mathrm{LVR}}(\cdot)\).
+
+**Return level (MEV-normalized, implement first):**
+
+\[
+\mathcal{N}_\pi := \frac{1}{\pi^{\mathrm{linear}}(t_0)},
+\qquad
+r^{\varphi}
+=
+r^{\phi}(r_{\mathrm{trans}}^{e})
+-
+r^{\mathrm{LVR}}\!\bigl(r_{\mathrm{arb}}^{e}\bigr),
+\qquad
+\pi^{\varphi} \approx \mathcal{N}_\pi^{-1}\, r^{\varphi}.
+\]
+
+Refs CPMM specialization: \(r^{\mathrm{LVR}}=\sigma_t^2\Delta t/8\), \(r^{\phi}=\phi_t\delta_{\mathrm{trans},t}\).
+
+---
+
+## §3 — RARB orthogonality (unchanged)
+
+Return split:
+
+\[
+r_{\Delta Q}^{e}
+=
+r_{\Delta Q_{\mathrm{trans}}}^{e}
++
+\beta\cdot r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{IV}-\sigma^{e}).
+\]
+
+Payoff composition for \(\pi^{\varphi}\) is **not** a single mixture on undifferentiated \(\pi^{\Delta Q}\):
+
+- Trans mixture: **only** \(r_{\mathrm{trans}}^{e}\) → `TransactionalExpectedReturn` (RARB spec)
+- Arb mixture: **only** \(r_{\mathrm{arb}}^{e}\) → `ArbExpectedReturn` (#21)
+- \(\pi^{\varphi}\): fee on trans **minus** LVR functional of arb leg
+
+Disambiguate \(\beta\) (RARB weight, #22) from any future \(\beta_{\mathrm{LVR}}\) if payoff-level affine is added later.
+
+---
+
+## §4 — π^LVR(π_arb^ΔQ) — minimal stub
+
+**Default (this cycle):** read **normalized return** from evaluated arb swap leg:
+
+1. Build \(\pi_{\mathrm{arb}}^{\Delta Q}\) via `runArbSwapAlongTenorMixture` (deferred #21; test with zero / placeholder leg until then).
+2. `lvrReturnFromArbSwap` = payoff along tenor / \(\pi^{\mathrm{linear}}(t_0)\) (MEV \(\mathcal{N}_\pi^{-1}\) convention).
+3. **CPMM sanity:** when arb leg is fair at pinned vol, recover \(r^{\mathrm{LVR}}=\sigma^2\Delta t/8\) within test tolerance.
+
+**Not:** independent Milionis scalar bypassing \(\pi_{\mathrm{arb}}^{\Delta Q}\).
+
+**Sign:** LVR is **subtracted** from \(\pi^{\phi}\); arb leg evaluation convention must match MEV (positive LVR cost).
+
+---
+
+## §5 — Module map and slices
+
+| Slice | Deliverable | Depends |
+|-------|-------------|---------|
+| **0** | Spec + README pointer | — |
+| **1** | `lvrReturnFromArbSwap` stub (return-only); tests with placeholder arb=0 | RARB trans tag optional |
+| **2** | `piVarphiFromTransArb` = fee path − LVR functional | #21 arb mixture, Slice 1 |
+| **3** | CLMM identity test: \(\pi^{c\|p}+\pi^{\mathrm{RAN}}\) vs \(\pi^{\varphi}\) at witness strike | Slice 2, `CLMMPosition` |
+| **4** | \(\mathbb{E}^{\mathbb{Q}}[m\cdot\pi^{\varphi}]\) | #17–#18 |
+
+**Planned modules:**
+
+- `Payoffs.LvrFromArbSwap` — `lvrReturnFromArbSwap`, later `lvrPayoffFromArbSwap`
+- `Payoffs.PiVarphi` — compose fee capture − LVR (or return-level first)
+
+---
+
+## §6 — Economic meaning
+
+For a concentrated-liquidity LP position decomposed as short option + range accrual (`CLMMPosition`), **net fee accrual after arbitrageur extraction** is \(\pi^{\varphi}=\pi^{\phi}-\pi^{\mathrm{LVR}}\). Fee revenue \(\pi^{\phi}\) accrues on **transactional** flow (\(\pi^{\mathrm{trans}}\) channel); LVR is the **gamma cost** read from the **arb swap leg** \(\pi_{\mathrm{arb}}^{\Delta Q}\), not from transactional mixture weights. The MEV tax objective maximizes \(\mathbb{E}[r^{\phi}-r^{\mathrm{LVR}}]=\mathbb{E}[r^{\varphi}]\) — this spec makes that identity explicit at the payoff level before measure #17–#18.
+
+---
+
+## §7 — Testing
+
+| Test | Slice |
+|------|-------|
+| `lvrReturnFromArbSwap` zero when arb leg zero | 1 |
+| CPMM: \(r^{\mathrm{LVR}}\approx\sigma^2\Delta t/8\) given fair arb fixture | 1–2 |
+| `piVarphi`: trans-only ⇒ equals fee capture path | 2 |
+| CLMM witness: call+RAN vs put+RAN unchanged; vs \(\pi^{\varphi}\) deferred until Slice 3 | 3 |
+
+---
+
+## Self-review
+
+- [x] π^arb ≡ π_arb^ΔQ explicit (choice A)
+- [x] No claim π^LVR = π_arb identically — functional read-off
+- [x] Orthogonal trans/arb parametrization consistent with RARB spec
+- [x] CLMM and MEV refs mapped to shipped modules
+- [x] Scope bounded; arb mixture deferred to #21

--- a/docs/superpowers/specs/2026-08-22-scratchpad-rarb-trans-flow-design.md
+++ b/docs/superpowers/specs/2026-08-22-scratchpad-rarb-trans-flow-design.md
@@ -1,0 +1,280 @@
+# Scratchpad RARB transactional flow — design
+
+**Status:** approved §1–§3 — plan TBD; TODO #7, #19, **#23** (\(\nu\) from `volume_path.gms`)  
+**Date:** 2026-08-22  
+**Repo:** `cfmm-theory` / package `scratchpad/`  
+**Brainstorm:** RARB split → orthogonally parametrized payoffs; trans leg exogenous; **prover-native** \(u\leftrightarrow\nu\) via `refs/volume_path.gms`  
+**Linked TODO:** #7, #19, **#23**, #17–#18 (measure), #20 (\(u=\ln(V/L)\)), #21–#22 (arb leg, \(\beta\))
+
+**Reads:** `scratchpad/README.md` (RARB block); `Payoffs/Swap.hs`; `Pricing/ExpectedReturn.hs`; `docs/superpowers/specs/2026-08-22-scratchpad-sigma-iv-latent-u-design.md`; `refs/MEV_TAX_MODEL_ONE_NOTES.md`; `refs/VOLATILITY_INTRUMENTS_MEV.md`; `refs/VOLUME_PATH.md`; **`refs/volume_path.gms`**
+
+---
+
+## Purpose
+
+Wire the **expected-return split (RARB)** to **orthogonally parametrized payoffs**:
+
+1. Transactional swap flow \(\pi_{\mathrm{trans}}^{\Delta Q}\) uses **only** exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) as control (approach **B**: tagged return type).
+2. Arb swap flow is a **separate** parametrization path (deferred: #21 + \(\beta\) #22).
+3. Latent **volume state** connects scratchpad \(u=\ln(V/L)\) (#20) with MEV **\(\nu\)** (volume-dimensional utilization) so \(\delta_{\mathrm{trans}}\) and \(r^\phi=\phi\,\delta_{\mathrm{trans}}\) (#7) align with existing MEV / volume-path results.
+
+**Out of scope this spec:** full `DiscountFactor` (#17), composed \(\pi^{\Delta Q}\) (#6 unblock), arb leg implementation, on-chain packing, AdaptiveStremia \(\phi(\Theta;\sigma^2,\nu)\) body (#5).
+
+---
+
+## §1 — RARB data flow (approved)
+
+Canonical split (scratchpad notation — **required**):
+
+\[
+r_{\Delta Q}^{e}
+=
+r_{\Delta Q_{\mathrm{trans}}}^{e}
++
+\beta\cdot r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{\mathrm{IV}},\sigma^{e}).
+\]
+
+| Channel | Control | Parametrized object | Cycle |
+|---------|---------|---------------------|-------|
+| Fee revenue | \(r_\phi^e\) | \(\pi^\phi(r_\phi^e)\) | **shipped** |
+| Swap (trans) | \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) **exogenous** | \(\pi_{\mathrm{trans}}^{\Delta Q}(r_{\mathrm{trans}}^{e})\) | **this spec** |
+| Swap (arb) | \(r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{IV},\sigma^{e})\) | \(\pi_{\mathrm{arb}}^{\Delta Q}\) | deferred |
+| Swap (full) | composed \(r_{\Delta Q}^{e}\) | \(\pi^{\Delta Q}\) affine sum | deferred (#6) |
+
+**Orthogonality rule:** code that builds transactional swap flow must **not** accept arb controls (\(\sigma_{\mathrm{IV}}\), \(\sigma^{e}\), \(\beta\), `volGap`). Only `TransactionalExpectedReturn`.
+
+**Planned composition (payoff level, later):**
+
+\[
+\pi^{\Delta Q}
+=
+\pi_{\mathrm{trans}}^{\Delta Q}(r_{\mathrm{trans}}^{e})
++
+\beta\cdot\pi_{\mathrm{arb}}^{\Delta Q}\bigl(r_{\mathrm{arb}}^{e}\bigr).
+\]
+
+Mirrors RARB at the return level; **not** a single mixture weight on one undifferentiated swap.
+
+---
+
+## §2 — Approach B: tagged transactional expected return (approved)
+
+### Newtypes
+
+| Haskell (planned) | Math | Role |
+|-------------------|------|------|
+| `TransactionalExpectedReturn` | \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) | Exogenous scalar control (#19); **only** input to trans swap mixture |
+| `ExpectedReturn` (existing) | \(r_\phi^e\), generic fee/swap shortcuts | Unchanged this cycle |
+| `ArbExpectedReturn` (deferred) | \(r_{\Delta Q_{\mathrm{arb}}}^{e}\) | From `volGap` + \(g\) (#21) |
+| `ComposedExpectedReturn` (deferred) | full RARB sum | #6 unblock |
+
+`TransactionalExpectedReturn` wraps `FeePips` (same Q96 mixture mechanics as `ExpectedReturn`) but is **not** interchangeable at call sites — prevents passing composed \(r_{\Delta Q}^{e}\) into the trans path.
+
+### API (Slice 1)
+
+```haskell
+-- Pricing.TransactionalExpectedReturn
+newtype TransactionalExpectedReturn = TransactionalExpectedReturn FeePips
+
+transactionalExpectedReturnWeightX96 :: TransactionalExpectedReturn -> Integer
+
+-- Payoffs.Swap (or Payoffs.TransSwap if file splits)
+runTransSwapAlongTenorMixture
+  :: InterestPriceMap
+  -> TransactionalExpectedReturn
+  -> Swap 'Pay 'Receive SqrtPriceX96 InterestSqrtX96
+  -> InterestTick
+  -> PayoffX96
+```
+
+Mechanics: identical to `runSwapAlongTenorMixture` / `expectedReturnWeightX96`, but weight sourced from `TransactionalExpectedReturn` only.
+
+### Tests (Slice 1)
+
+- Trans mixture with weight 0 / 1 / interior matches pay-only / recv-only / blend (mirror existing swap mixture tests).
+- Type-level story documented: trans runner has no `ImpliedVolatility` / `ExpectedVolatility` / arb parameters in signature.
+
+---
+
+## §3 — Prover-native \(u\leftrightarrow\nu\) (option **B**, approved)
+
+### Canonical coupling: `volume_path.gms` shock vector
+
+The scratchpad **does not** treat \(\nu_{\mathrm{trans}}\) as an independent exogenous input (option A is **pre-prover stub only**). The canonical contract matches `refs/volume_path.gms`:
+
+| GAMS input | Math | Scratchpad |
+|------------|------|------------|
+| `volTgtWad` | \(V=\sum|\Delta Q_X|\) | \(V=L\,e^u\) (#20) |
+| `liquidityRaw` | \(\bar L\) | `TickLiquidity` |
+| `txlVolumeRate` | \(\delta^\*\) | target transactional rate |
+| `kappa = volTgt/Lbar` | \(V/\bar L\) | **\(e^u\)** — so \(u=\ln\kappa=\ln(V/\bar L)\) at the prover boundary |
+
+Prover **outputs** certify `deltaRealized`, `rPhiRealized`, `dQx[]`, `dQM[]`. Post-process:
+
+\[
+\nu_{\mathrm{trans}}=\sum_j\sqrt{\bar p\,|\Delta Q_X(j)\,\Delta Q_M(j)|},
+\qquad
+\bar\pi=\sum_j\bigl(\bar p|\Delta Q_X|+|\Delta Q_M|\bigr),
+\qquad
+g\equiv\frac{\nu_{\mathrm{trans}}}{V}.
+\]
+
+**Shock workflow (bridge / differential test):**
+
+1. T0 IV pin: \(u\leftarrow u^\star(\sigma_X,\phi)\) **or** shock-driven \(u=\ln(\texttt{volTgtWad}/\bar L)\).
+2. Set \(V=\bar L\,e^u\) → `volTgtWad`; set \(\delta^\*\) → `txlVolumeRate`; pool → `sqrtPriceX96`, `liquidityRaw`, fees.
+3. Run `volume_path.gms`; abort if precheck fails (half-ellipse, \(\kappa\) floor — see `VOLUME_PATH.md` §1).
+4. From JSON: compute \(\nu_{\mathrm{trans}}\), \(g=\nu_{\mathrm{trans}}/V\); assert \(\nu_{\mathrm{trans}}/\bar\pi\approx\delta^\*\).
+
+### Derived \(\nu_{\mathrm{trans}}\) off JSON (golden \(g\))
+
+When JSON is unavailable (along-tenor estimates, unit tests without GAMS):
+
+\[
+\nu_{\mathrm{trans}}(N)=V(N)\,g(\delta^\*,\kappa,\bar p,\bar\phi_X,\bar\phi_M,N),
+\qquad
+V=\bar L\,e^u,
+\qquad
+\kappa=V/\bar L.
+\]
+
+**Finding \(g\):** grid `volume_path.gms` over feasible \((\delta^\*,\kappa,\phi_X,\phi_M,N)\); tabulate \(g=\nu_{\mathrm{trans}}/V\) from each converged solve (`make test-gams` / golden JSON). Uniform-step closed form \(g\approx\delta^\*\,\bar p/(1-x(\delta^\*))\) is **doc approximation only** — prover table wins when they differ (small \(\kappa\) regime).
+
+**Pre-prover stub (option A, temporary):** `NuTrans` as caller-supplied scalar in Slice 2 **must** be labeled pre-prover; default target is replay/table from §3. Do **not** treat exogenous \(\nu\) and IV-pinned \(u\) as jointly valid without GAMS feasibility.
+
+### MEV references (economics + dynamics)
+
+- Cumulative \(\nu_{\mathrm{trans}}\), \(\delta_{\mathrm{trans}}^{\mathrm{MEV}}=\nu_{\mathrm{trans}}/\bar\pi\): `MEV_TAX_MODEL_ONE_NOTES.md`.
+- Event-time \(\nu(t)\), \(\partial\nu/\partial t\): `VOLATILITY_INTRUMENTS_MEV.md` (Theorem 36).
+- Scratchpad **does not** import MEV \(\Delta\pi_{\mathrm{trans}}/\pi_{\mathrm{trans}}\) labels (#7).
+
+### \(\pi_{\mathrm{trans}}^{\Delta Q}\) and \(\delta_{\mathrm{trans}}\)
+
+**Transactional swap payoff (parametrized):**
+
+\[
+\pi_{\mathrm{trans}}^{\Delta Q}(t)
+\;\equiv\;
+\mathtt{runTransSwapAlongTenorMixture}\bigl(\mathrm{ipm},\, r_{\mathrm{trans}}^{e},\, \mathrm{swap},\, t\bigr).
+\]
+
+**Transactional rate (scratchpad pin — revised numerator):**
+
+\[
+\delta_{\mathrm{trans}}(t)
+\;\equiv\;
+\frac{\nu_{\mathrm{trans}}(t)}{\pi_{\mathrm{trans}}^{\Delta Q}(t)}.
+\]
+
+- Numerator **\(\nu_{\mathrm{trans}}\)** (volume-dimensional, latent, MEV-linked dynamics) replaces the draft README numerator \(u(t)\) alone.
+- Denominator **\(\pi_{\mathrm{trans}}^{\Delta Q}\)** is the trans-only parametrized swap payoff — not MEV \(\bar\pi\), but **homogeneous** so the ratio is a **rate** suitable for \(r^\phi=\phi\,\delta_{\mathrm{trans}}\).
+
+**Connection to MEV economics (citation only for volume share):**
+
+\[
+\delta_{\mathrm{trans}}^{\mathrm{MEV}}
+=
+\frac{\nu_{\mathrm{trans}}}{\bar\pi}
+\]
+
+recovered when \(\pi_{\mathrm{trans}}^{\Delta Q}\) aligns with the MEV linear-flow denominator \(\bar\pi\) along a certified volume path. Scratchpad keeps MEV \(\Delta\pi_{\mathrm{trans}}/\pi_{\mathrm{trans}}\) labels **out** of code (#7); cite `refs/` for motivation.
+
+**Fee return link (#7, Slice 2):**
+
+\[
+r^{\phi}=\phi\cdot\delta_{\mathrm{trans}},
+\qquad
+r_\phi^e \;\text{eventually}\; \mathbb E[m(\phi)\cdot\pi^\phi]
+\;\text{with trans control from}\;
+\delta_{\mathrm{trans}}.
+\]
+
+Distinct from payoff \(\pi^\phi\) (already shipped).
+
+### \(u\) still enters arb leg, not trans parametrization
+
+- Trans leg parametrization: **only** \(r_{\Delta Q_{\mathrm{trans}}}^{e}\).
+- \(u\) / \(\nu\) enter **rates** (\(\delta_{\mathrm{trans}}\), \(\sigma_{\mathrm{IV}}\)) and **arb** leg (#21), not the trans mixture weight.
+
+---
+
+## §4 — Module map and slices
+
+| Slice | Deliverable | Depends |
+|-------|-------------|---------|
+| **1** | `TransactionalExpectedReturn`, `runTransSwapAlongTenorMixture`, tests | — |
+| **2** | \(\delta_{\mathrm{trans}}=\nu_{\mathrm{trans}}/\pi_{\mathrm{trans}}^{\Delta Q}\); \(r^\phi=\phi\,\delta_{\mathrm{trans}}\) stub; pre-prover `NuTrans` optional | Slice 1, #20 T0 |
+| **3** | **#23:** JSON replay \(\nu_{\mathrm{trans}}\) from `dQx`/`dQM`; golden \(g\) table from `volume_path.gms`; \(u=\ln\kappa\) shock helper | `refs/volume_path.gms`, Slice 2 |
+| **4** | T1 observer; `tenorTickPath` vs prover path consistency | #20 T1 |
+| **5** | `ArbExpectedReturn`, compose \(\pi^{\Delta Q}\), full RARB | #17–#18, #21, #22 |
+
+**Files (Slice 1):**
+
+- `src/Pricing/TransactionalExpectedReturn.hs`
+- `src/Payoffs/Swap.hs` — add `runTransSwapAlongTenorMixture`
+- `test/Spec.hs`
+- `README.md` — replace WIP prose with spec pointer; **preserve** user RARB / \(\delta_{\mathrm{trans}}\) block; fix numerator \(u\to\nu_{\mathrm{trans}}\) when approved
+
+---
+
+## §5 — Symbol hygiene
+
+| Symbol | Meaning | Not |
+|--------|---------|-----|
+| \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) | Exogenous trans expected return | MEV \(\Delta\pi/\pi\) |
+| \(\pi_{\mathrm{trans}}^{\Delta Q}\) | Parametrized trans swap payoff | Full \(\pi^{\Delta Q}\) |
+| \(u\) | \(\ln(V/L)\) | Mixture weight |
+| \(\nu\), \(\nu_{\mathrm{trans}}\) | Volume-dimensional utilization / cumulative trans flow | Fee-mix \(\kappa\) |
+| \(\delta_{\mathrm{trans}}\) | \(\nu_{\mathrm{trans}}/\pi_{\mathrm{trans}}^{\Delta Q}\) (scratchpad) | Raw \(u/\pi\) without \(\nu\) bridge |
+| \(\beta\) | RARB arb weight (#22) | CES \(\beta=\eta\), logistic \(\beta_j\) |
+
+---
+
+## §6 — Economic meaning
+
+In a Uniswap-style pool with latent nominal volume \(V\) and observed liquidity \(L\):
+
+- **Transactional traders** face swap payoffs parametrized by an **exogenous** expected return \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) — the LP does not infer this from arb vol gaps; it is a control / market input (#19).
+- **Arbitrageurs** (later) face a **different** parametrization driven by \(\sigma_{\mathrm{IV}}-\sigma^{e}\) — orthogonal to trans flow in RARB.
+- **\(\nu_{\mathrm{trans}}\)** is the effective transactional volume accumulated along the tenor (MEV geometric-flow measure); linking it to \(u=\ln(V/L)\) ties **fee/market IV state** to **flow utilization dynamics** already analyzed in the MEV tax model.
+- **\(\delta_{\mathrm{trans}}\)** is the ratio of latent trans volume intensity to the parametrized trans swap payoff — the scalar that scales **fee return** \(r^\phi=\phi\,\delta_{\mathrm{trans}}\) without conflating fee payoff \(\pi^\phi\).
+
+---
+
+## §7 — Testing
+
+| Test | Slice |
+|------|-------|
+| Trans mixture weights 0 / 1 / interior | 1 |
+| Trans API has no arb/vol parameters in type | 1 |
+| \(\delta_{\mathrm{trans}}\) dimensionless rate from stub \(\nu_{\mathrm{trans}}\), evaluated \(\pi_{\mathrm{trans}}^{\Delta Q}\) | 2 |
+| \(r^\phi=\phi\cdot\delta_{\mathrm{trans}}\) FeePips round-trip | 2 |
+| JSON replay: \(\nu_{\mathrm{trans}}\), \(g\) vs fixture `volume_path.json` | 3 |
+| Golden \(g(\delta^\*,\kappa,\phi)\) within tol of GAMS grid | 3 |
+| T0: \(V=L e^u\) ↔ `volTgtWad`/`liquidityRaw` shock encoding | 3 |
+
+---
+
+## §8 — README delta (when spec approved)
+
+Replace draft numerator in user RARB block:
+
+```diff
+- \delta_{\text{trans}} (t) \equiv u(t) / \pi_{\text{trans}}^{\Delta Q}
++ \delta_{\text{trans}} (t) \equiv \nu_{\text{trans}}(t) / \pi_{\text{trans}}^{\Delta Q}(t)
++ \quad\text{with}\quad V(t)=L(i(t))\,e^{u(t)},\; u=\ln(V/L)\;\text{(#20)}.
+```
+
+Add spec link; keep `(RARB)` tag and user prose.
+
+---
+
+## Self-review (inline)
+
+- [x] No TBD placeholders in core Slice 1–2 requirements
+- [x] Orthogonality: trans parametrization excludes arb inputs — explicit
+- [x] MEV \(\delta_{\mathrm{trans}}=\nu_{\mathrm{trans}}/\bar\pi\) cited as economics limit, not wrong scratchpad labels
+- [x] Prover-native B coupling; option A pre-prover stub only
+- [x] \(u=\ln\kappa\) at GAMS boundary; \(g\) from golden replay not hand-waved
+- [x] Scope bounded: Slice 1 is trans tag + mixture only
+- [x] Consistent with shipped `runSwapAlongTenorMixture` / `feeRevenueExpectedReturn` pattern

--- a/src/Volatility/ExpectedVolatility.hs
+++ b/src/Volatility/ExpectedVolatility.hs
@@ -1,0 +1,87 @@
+module Volatility.ExpectedVolatility
+  ( ExpectedVolatility(..)
+  , unExpectedVolatility
+  , RealizedVolatility(..)
+  , unRealizedVolatility
+  , VolHorizon(..)
+  , VolGap(..)
+  , unVolGap
+  , realizedVolatilityFromAverage
+  , expectedVolatilityWindowStub
+  , tenorTickPath
+  , expectedVolatilityUniformTenor
+  , volGap
+  ) where
+
+import qualified Data.Vector as V
+import Pricing.InterestPriceMap (InterestPriceMap, priceTickAt)
+import Pricing.InterestSqrt (InterestTick, mkInterestTick, unInterestTick)
+import TickPath (TickPath(..))
+import Volatility.ImpliedVolatility (ImpliedVolatility, unImpliedVolatility)
+import Volatility.TickVolatility
+  ( VolatilityAverage(..)
+  , averageVolatility
+  , unVolatilityAverage
+  )
+
+-- | σ^e in Algebra oracle integer units (same as VolatilityAverage).
+newtype ExpectedVolatility = ExpectedVolatility Integer
+  deriving (Show, Eq)
+
+unExpectedVolatility :: ExpectedVolatility -> Integer
+unExpectedVolatility (ExpectedVolatility x) = x
+
+newtype RealizedVolatility = RealizedVolatility Integer
+  deriving (Show, Eq)
+
+unRealizedVolatility :: RealizedVolatility -> Integer
+unRealizedVolatility (RealizedVolatility x) = x
+
+newtype VolGap = VolGap Integer
+  deriving (Show, Eq)
+
+unVolGap :: VolGap -> Integer
+unVolGap (VolGap x) = x
+
+data VolHorizon
+  = OracleWindowHorizon
+  | TenorHorizon InterestTick
+  deriving (Show, Eq)
+
+realizedVolatilityFromAverage :: VolatilityAverage -> RealizedVolatility
+realizedVolatilityFromAverage (VolatilityAverage x) = RealizedVolatility x
+
+-- VISIBLE NOTE: Slice 1 non-𝔼^Q stub — WINDOW ensemble deferred to Slice 3.
+expectedVolatilityWindowStub :: VolatilityAverage -> ExpectedVolatility
+expectedVolatilityWindowStub (VolatilityAverage x) = ExpectedVolatility x
+
+tenorTickPath :: InterestPriceMap -> InterestTick -> InterestTick -> TickPath
+tenorTickPath ipm t0 tR =
+  let
+    a = unInterestTick t0
+    b = unInterestTick tR
+    lo = min a b
+    hi = max a b
+    n = hi - lo + 1
+    vec =
+      V.generate n $ \j ->
+        priceTickAt ipm (mkInterestTick (lo + j))
+  in
+    if n >= 2
+      then TickPath n vec
+      else
+        let ti = priceTickAt ipm t0
+        in TickPath 2 (V.replicate 2 ti)
+
+expectedVolatilityUniformTenor
+  :: InterestPriceMap
+  -> InterestTick
+  -> InterestTick
+  -> ExpectedVolatility
+expectedVolatilityUniformTenor ipm t0 tR =
+  ExpectedVolatility $
+    unVolatilityAverage (averageVolatility (tenorTickPath ipm t0 tR))
+
+volGap :: ImpliedVolatility -> ExpectedVolatility -> VolGap
+volGap iv (ExpectedVolatility ev) =
+  VolGap (unImpliedVolatility iv - ev)

--- a/src/Volatility/ImpliedVolatility.hs
+++ b/src/Volatility/ImpliedVolatility.hs
@@ -1,0 +1,18 @@
+module Volatility.ImpliedVolatility
+  ( ImpliedVolatility(..)
+  , unImpliedVolatility
+  , impliedVolatilityFromAverage
+  ) where
+
+import Volatility.TickVolatility (VolatilityAverage(..))
+
+-- | Kristensen σ_IV word (full u-map in TODO #20).
+newtype ImpliedVolatility = ImpliedVolatility Integer
+  deriving (Show, Eq)
+
+unImpliedVolatility :: ImpliedVolatility -> Integer
+unImpliedVolatility (ImpliedVolatility x) = x
+
+-- Slice 1 stand-in until uStarFromCalibration lands.
+impliedVolatilityFromAverage :: VolatilityAverage -> ImpliedVolatility
+impliedVolatilityFromAverage (VolatilityAverage x) = ImpliedVolatility x

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -205,7 +205,7 @@ import State (pattern SQRT_PRICE_1_4, pattern SQRT_PRICE_4_1)
 import StrikeX96 (StrikeX96(..))
 import Data.Vector ((!))
 import qualified Data.Vector as V
-import TickPath (TickPath(..), mkTickPath)
+import TickPath (TickPath(..), mkTickPath, pathLength, ticks)
 import Payoffs.VolatilityCall
   ( mkVolStrike
   , payoff
@@ -230,8 +230,21 @@ import Volatility.TickVolatility
   , VolatilityAverage(..)
   , averageVolatility
   , rangeAlongPath
+  , unVolatilityAverage
   , volatilityOnRange
   )
+import Volatility.ExpectedVolatility
+  ( ExpectedVolatility(..)
+  , expectedVolatilityUniformTenor
+  , expectedVolatilityWindowStub
+  , realizedVolatilityFromAverage
+  , tenorTickPath
+  , unExpectedVolatility
+  , unRealizedVolatility
+  , unVolGap
+  , volGap
+  )
+import Volatility.ImpliedVolatility (impliedVolatilityFromAverage)
 import Volatility.VolatilityGrid (gammaCoordinate)
 
 assertThrows :: forall a. String -> a -> IO ()
@@ -655,6 +668,55 @@ main = do
     "constant path ⇒ rangeAlongPath all 0"
     (V.replicate 7 (RangeVolatility 0))
     constantRanges
+
+  -- ExpectedVolatility Slice 1
+  let volAvg0 = VolatilityAverage 0
+  assertEqual
+    "realizedVolatilityFromAverage round-trip"
+    0
+    (unRealizedVolatility (realizedVolatilityFromAverage volAvg0))
+  assertEqual
+    "expectedVolatilityWindowStub = realized (Slice 1 stub)"
+    0
+    (unExpectedVolatility (expectedVolatilityWindowStub volAvg0))
+  let
+    ipmTen = mkInterestPriceMap 1 0
+    t0Vol = mkInterestTick 0
+    t7Vol = mkInterestTick 7
+    flatPathVol = TickPath 8 (V.replicate 8 0)
+    evFlat = expectedVolatilityUniformTenor ipmTen t0Vol t0Vol
+    path07 = tenorTickPath ipmTen t0Vol t7Vol
+  assertEqual
+    "tenorTickPath t0→t7 length"
+    8
+    (pathLength path07)
+  assertEqual
+    "tenorTickPath t0 tick"
+    0
+    (ticks path07 ! 0)
+  assertEqual
+    "tenorTickPath t7 tick"
+    7
+    (ticks path07 ! 7)
+  assertEqual
+    "uniform tenor flat t0=t0 ⇒ σ^e=0"
+    0
+    (unExpectedVolatility evFlat)
+  assertEqual
+    "uniform tenor flat matches averageVolatility constant path"
+    (unVolatilityAverage (averageVolatility flatPathVol))
+    (unExpectedVolatility (expectedVolatilityUniformTenor ipmTen t0Vol t0Vol))
+  let
+    ivGap = impliedVolatilityFromAverage (VolatilityAverage 100)
+    evGap = ExpectedVolatility 40
+  assertEqual
+    "volGap σ_IV − σ^e"
+    60
+    (unVolGap (volGap ivGap evGap))
+  assertEqual
+    "volGap zero when equal"
+    0
+    (unVolGap (volGap ivGap (ExpectedVolatility 100)))
 
   let
     bookPath = TickPath 8 (V.generate 8 (\x -> x * 10))


### PR DESCRIPTION
## Summary
- Implements TODO #21 Slice 1: `Volatility.ExpectedVolatility` (uniform tenor, window stub, `volGap`, `tenorTickPath`) and minimal `Volatility.ImpliedVolatility` newtype
- Adds implementation plan, spec status update, tests, and README module tree + shipped note (preserves user RARB / δ_trans prose)

## Linked issue
Solves #31

## Test plan
- [x] `stack build --pedantic && stack test`
- [x] ExpectedVolatility / volGap asserts in `test/Spec.hs`


Made with [Cursor](https://cursor.com)