### PR TITLE
docs(todo-25): π̂^σ as 4-leg Panoptic position over π^φ(liquidity chunk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,5 @@
 
-# PRIMITIVES
-
-
-
-# PAYOFFS
-Consider:
-
-
-For the payoff type \(\pi (K; P)\) we have:
-
-
-\[
-	\begin{aligned}
-	    \pi (K \, + \, \Delta K; P) \, &=  \pi (K; P) \, + \, \Delta K \, \frac{\partial \pi (K; P)}{\partial K}
-	\end{aligned}
-\]
-
-This is an endomorphism on the payoff space:
-\[
-	\begin{aligned}
-	    \mathcal{D}_{\Delta K}^K \, &\equiv \, \pi (K; P) \, + \, \Delta K \, \frac{\partial \pi (K; P)}{\partial K}
-	\end{aligned}
-\]
-
-
-Then: 
-
-\[
-	\begin{aligned}
-		\pi (K \, + \, \Delta K; P) \, &= \mathcal{D}_{\Delta K}^K \, \pi (K ; P)
-	\end{aligned}
-\]
-
-
-
 # RANGE_ACCRUAL_NOTE
-
-where
-
-\[
-\pi^{\text{RA}}(k,r;p)=
-\begin{cases}
-	0, & p < \frac{k}{r}, \\[4pt]
-	\dfrac{2\sqrt{pkr} - pr - k}{r-1}, & \frac{k}{r} \le p < k, \\[8pt]
-	\dfrac{2\sqrt{pkr} - p - kr}{r-1}, & k \le p < kr, \\[8pt]
-	0, & p \ge kr.
-\end{cases}
-\]
-
 
 The sqrt-coordinate range payoff is
 
@@ -64,6 +16,95 @@ The sqrt-coordinate range payoff is
 	\end{aligned}
 \]
 
+
+\[
+\pi^{c|p} + \pi^{\mathrm{RAN}} \equiv \pi^{\varphi} \equiv \pi^{\phi} - \pi^{\mathrm{LVR}}
+\]
+
+
+
+The **contractual** volatility payoff is as defined on VOLATILITY_INSTRUMENTS:
+
+\[
+	\begin{aligned}
+		\pi^{\sigma} \, &\equiv \Delta Q_{\upsilon} \, \Big (\sigma (i(t)) \, - \, \sigma_K\Big)^{+}
+	\end{aligned}
+\]
+
+And the option-replica volatility payoff is the **4-leg Panoptic position** (`MintPlan` = `PanopticTokenId` + `LiquidityChunk`), built on Uniswap liquidity positions. Objects, in the order the code constructs them:
+
+**Liquidity chunk** (`Liquidity.LiquidityChunk.createChunk`):
+
+\[
+	\begin{aligned}
+		\ell \, &\equiv \, (i^{-}, \, i^{+}, \, L), \qquad i^{-} < i^{+}, \quad 0 < L < 2^{128}, \qquad
+		p_{1/2}(i) \, \equiv \, 1.0001^{\,i/2}
+	\end{aligned}
+\]
+
+**\(\pi^{\varphi}\) as a function of a chunk** — the Uniswap V3 position value held by the SFPM (linear in \(L\), concave in \(p_{1/2}\)):
+
+\[
+	\begin{aligned}
+		\pi^{\varphi}(\ell;\, p_{1/2}) \, &\equiv \,
+		\begin{cases}
+			L \, p_{1/2}^{2} \Big( \dfrac{1}{p_{1/2}(i^{-})} - \dfrac{1}{p_{1/2}(i^{+})} \Big), & p_{1/2} < p_{1/2}(i^{-}) \\[8pt]
+			L \Big( 2 p_{1/2} - p_{1/2}(i^{-}) - \dfrac{p_{1/2}^{2}}{p_{1/2}(i^{+})} \Big), & p_{1/2}(i^{-}) \le p_{1/2} < p_{1/2}(i^{+}) \\[8pt]
+			L \Big( p_{1/2}(i^{+}) - p_{1/2}(i^{-}) \Big), & p_{1/2} \ge p_{1/2}(i^{+})
+		\end{cases}
+	\end{aligned}
+\]
+
+CLMM identity (TODO #24, `CLMMPosition`): with \(\kappa_{1/2} = \sqrt{p_{1/2}(i^{-}) \, p_{1/2}(i^{+})}\), \(r = p(i^{+})/p(i^{-})\),
+
+\[
+	\begin{aligned}
+		\pi^{\varphi}(\ell;\, p_{1/2}) \, &= \, L \cdot c(\kappa, r) \, \Big[ \pi^{c|p}(\kappa) + \pi^{\mathrm{RAN}}(\kappa, r) \Big]
+	\end{aligned}
+\]
+
+> OPEN: the normalization \(c(\kappa,r)\) between `CLMMPosition` (unit, \(\kappa\)-normalized) and the Uniswap \(L\)-normalized form above is the CLMM identity test of TODO #24 — asserted here, not verified. The entry point is the full \(\pi^{\varphi} = \pi^{c|p}+\pi^{\mathrm{RAN}}\), **not** \(\pi^{c|p}\) alone: \(\pi^{c|p} = \min(P,K)\) is width-blind; the Panoptic `width` field enters only through \(\pi^{\mathrm{RAN}}\).
+
+**Leg geometry** (`Volatility.VolOrder.legIntervals`): from \((i_L, i_U)\) (width/skew about \(i^{\star}\), `tickBucketFromVolOrder`) and split points \(m_P, m_C\) (`volOrderSplitPoints`):
+
+\[
+	\begin{aligned}
+		(i_k^{-}, i_k^{+})_{k=0}^{3} \, &= \, \big[ i_L, m_P \big), \; \big[ m_P, i^{\star} \big), \; \big[ i^{\star}, m_C \big), \; \big[ m_C, i_U \big] \\
+		\texttt{tokenType}(k) \, &= \, 0 \;\; (\text{put}), \; k \in \{0,1\}; \qquad 1 \;\; (\text{call}), \; k \in \{2,3\} \\
+		\texttt{isLong}(k) \, &= \, 1 \qquad \forall k
+	\end{aligned}
+\]
+
+**Per-leg option ratio and leg chunk** (`optionRatio` field, \(\mathrm{or}(k) \in \{1, \dots, 127\}\)); \(\Delta Q_{\upsilon}\) = SFPM `positionSize` = `targetVegaFromMint`:
+
+\[
+	\begin{aligned}
+		L_k \, &\equiv \, \Lambda \Big( i_k^{-}, \, i_k^{+}; \; \mathrm{or}(k) \cdot \Delta Q_{\upsilon} \Big), \qquad
+		\ell_k \, \equiv \, (i_k^{-}, \, i_k^{+}, \, L_k)
+	\end{aligned}
+\]
+
+where \(\Lambda\) is the Uniswap amount\(\to\)liquidity map over the leg range (token0 amount for calls, token1 for puts). \(\Delta Q_{\upsilon}\) scales every leg linearly.
+
+**4-leg replica.** A long Panoptic leg pays the OTM mint value of its chunk minus the cost to return that chunk's liquidity at the current price:
+
+\[
+	\begin{aligned}
+		\hat{\pi^{\sigma}}(p_{1/2}) \, &\equiv \, \sum_{k=0}^{3} \, \Big[ \pi^{\varphi}\big(\ell_k;\, p^{\star}_{1/2}\big) \, - \, \pi^{\varphi}\big(\ell_k;\, p_{1/2}\big) \Big]
+	\end{aligned}
+\]
+
+Legs are OTM at \(p^{\star}\), so \(\pi^{\varphi}(\ell_k; p^{\star}_{1/2})\) is a constant per leg: \(L_k \big(p_{1/2}(i_k^{+}) - p_{1/2}(i_k^{-})\big)\) for puts, \(L_k \, p^{\star} \big(1/p_{1/2}(i_k^{-}) - 1/p_{1/2}(i_k^{+})\big)\) for calls. This is the bridge \(\hat{\pi^{\sigma}} = f(\pi^{\varphi})\): \(f\) is \(x \mapsto \sum_k [\mathrm{const}_k - x_k]\) on the leg vector \(\big(\pi^{\varphi}(\ell_k)\big)_k\), convex in \(p_{1/2}\) because each \(-\pi^{\varphi}(\ell_k)\) is. Substituting \(\pi^{\varphi} = \pi^{\phi} - \pi^{\mathrm{LVR}}\):
+
+\[
+	\begin{aligned}
+		\hat{\pi^{\sigma}} \, &= \, \sum_{k=0}^{3} \, \Big[ \pi^{\mathrm{LVR}}(\ell_k) \, - \, \pi^{\phi}(\ell_k) \Big] \, + \, \sum_{k=0}^{3} \pi^{\varphi}\big(\ell_k;\, p^{\star}_{1/2}\big)
+	\end{aligned}
+\]
+
+Long vol = LVR extracted from the borrowed chunks minus the fees forgone (streamia) on them.
+
+Remarks (not definitions): (i) shipped Hop A/B \(\Delta Q_{\upsilon}\big[N_{\mathrm{id}}(F - \mathrm{Log}) + R\big]\) (`VariancePortfolio`) is the Carr–Madan continuum limit of the 4-leg sum; (ii) MEV \(\sum_i L(i)\,\pi^{\varphi}(i)\) is the **short** side of this same book, hence not ground truth for \(\hat{\pi^{\sigma}}\). Gaps in code: `volOrderToMintPlan` builds one envelope chunk \((i_L, i_U, \Delta Q_{\upsilon})\), not four \(\ell_k\); \(\Lambda\) and \(\mathrm{or}(k) \to L_k\) are not implemented (`OptionRatio.hs` TODO).
 
 ## PRICING GEOMETRY
 
@@ -92,66 +133,82 @@ Then the structure is now
 
 ```
 src/
-├── Payoffs/  // payoffs and returns only
-│   ├── Payoff.hs
-│   ├── CoveredCall.hs
-│   ├── CashSecuredPut.hs
-│   ├── RangeAccrualNote.hs
-│   ├── CLMMPosition.hs
-│   ├── VolatilityCall.hs
-│   ├── Forward.hs
-│   ├── Log.hs
-│   ├── Linear.hs
-│   ├── Return.hs
-│   ├── Savings.hs
-│   ├── Swap.hs
-│   ├── TransactionalFeeCapture.hs
-│   └── VariancePortfolio.hs
-├── Panoptic/
-│   ├── NId.hs
-│   └── MintPlan.hs
-├── Plotting/
-│   ├── PlotSqrt.hs
-│   ├── PlotInterest.hs
-│   └── PlotUtils.hs
-├── Pricing/
-│   ├── PriceDeformation.hs
-│   ├── Stremia.hs
-│   ├── AdaptiveStremia.hs
-│   ├── FeeStructure.hs
-│   ├── MarkUpStructure.hs
-│   ├── ExpectedReturn.hs
-│   ├── DiscountFactor.hs   // planned (TODO #17): parametric m(·)
-│   ├── InterestSqrt.hs
-│   └── InterestPriceMap.hs
-├── Trading/
-│   ├── PriceImpact.hs
-│   ├── Quote.hs
-│   └── KappaCoordinate.hs
-├── Greeks/
-│   ├── Delta.hs
-│   ├── Gamma.hs
-│   ├── Theta.hs
-│   └── Vega.hs
-├── Liquidity/
-│   ├── LiquidityChunk.hs
-│   ├── LiquidityGrid.hs
-│   ├── LiquidityDensity.hs
-│   └── TickLiquidity.hs
-├── Volatility/
-│   ├── VolOrder.hs
-│   ├── VolatilityGrid.hs
-│   ├── VolTermStructure.hs
-│   ├── TickVolatility.hs
-│   └── CevField.hs
-├── TickPath.hs
-├── SqrtGrid.hs
-├── StrikeX96.hs
+├── Greeks
+│   ├── Delta.hs
+│   ├── Gamma.hs
+│   ├── Theta.hs
+│   └── Vega.hs
+├── Lib.hs
+├── Liquidity
+│   ├── LiquidityChunk.hi
+│   ├── LiquidityChunk.hs
+│   ├── LiquidityChunk.o
+│   ├── LiquidityDensity.hs
+│   ├── LiquidityGrid.hi
+│   ├── LiquidityGrid.hs
+│   ├── LiquidityGrid.o
+│   ├── TickLiquidity.hi
+│   ├── TickLiquidity.hs
+│   └── TickLiquidity.o
 ├── OptionRatio.hs
+├── Panoptic
+│   ├── MintPlan.hs
+│   └── NId.hs
+├── Payoffs
+│   ├── CashSecuredPut.hs
+│   ├── CLMMPosition.hs
+│   ├── CoveredCall.hs
+│   ├── Forward.hs
+│   ├── Linear.hs
+│   ├── Log.hs
+│   ├── Payoff.hs
+│   ├── RangeAccrualNote.hs
+│   ├── Return.hs
+│   ├── Savings.hs
+│   ├── Swap.hs
+│   ├── TransactionalFeeCapture.hs
+│   ├── VariancePortfolio.hs
+│   └── VolatilityCall.hs
+├── Plotting
+│   ├── PlotInterest.hs
+│   ├── PlotSqrt.hs
+│   └── PlotUtils.hs
+├── Pricing
+│   ├── AdaptiveStremia.hs
+│   ├── ExpectedReturn.hs
+│   ├── FeeStructure.hs
+│   ├── InterestPriceMap.hs
+│   ├── InterestSqrt.hs
+│   ├── MarkUpStructure.hs
+│   ├── PriceDeformation.hi
+│   ├── PriceDeformation.hs
+│   ├── PriceDeformation.o
+│   └── Stremia.hs
+├── SqrtGrid.hi
+├── SqrtGrid.hs
+├── SqrtGrid.o
+├── State.hs
+├── StrikeX96.hs
 ├── TargetVega.hs
-└── State.hs
+├── TickPath.hs
+├── Trading
+│   ├── KappaCoordinate.hi
+│   ├── KappaCoordinate.hs
+│   ├── KappaCoordinate.o
+│   ├── PriceImpact.hs
+│   └── Quote.hs
+└── Volatility
+    ├── CevField.hs
+    ├── ExpectedVolatility.hs
+    ├── ImpliedVolatility.hs
+    ├── TickVolatility.hs
+    ├── VolatilityGrid.hi
+    ├── VolatilityGrid.hs
+    ├── VolatilityGrid.o
+    ├── VolOrder.hs
+    └── VolTermStructure.hs
 
-outputs/{Pricing,Payoffs,Payoffs/Returns,Greeks,Liquidity,TickPath,Volatility}/
+
 ```
 
 \[
@@ -222,9 +279,9 @@ r_\phi^e\,\phi_M I(r_{1/2})
 
 where for returns we have expectations:
 
-
+> This is corrected, the formula is for prices
 \[
-r_\phi^e
+p^{\phi}
 =
 \mathbb E\!\left[m(\phi,\Delta Q)\cdot \pi^{\Delta Q}\right]
 \qquad\text{(via swap channel)}


### PR DESCRIPTION
## Summary
- Tracks / delivers the design-note half of TODO.md #25 (`docs`): pins \(\hat\pi^\sigma = f(\pi^\varphi)\) from the Haskell objects rather than MEV Σ.
- README block now defines: liquidity chunk \(\ell=(i^-,i^+,L)\); \(\pi^\varphi(\ell;p_{1/2})\) as the Uniswap V3 position value; leg geometry (`VolOrder.legIntervals`); per-leg \(\mathrm{or}(k)\to L_k\); and
  \(\hat\pi^\sigma \equiv \sum_{k=0}^{3}[\pi^\varphi(\ell_k;p^\star)-\pi^\varphi(\ell_k;p)]\), then via \(\pi^\varphi=\pi^\phi-\pi^{\mathrm{LVR}}\).
- Carr–Madan / Hop A/B `VariancePortfolio` kept as a remark (continuum limit), not the definition. Resolves the old "TH entry via π^{c|p} must be revised" note: entry is full \(\pi^{c|p}+\pi^{\mathrm{RAN}}\).
- Open items flagged in-text: CLMM normalization \(c(\kappa,r)\) (TODO #24 test), \(\Lambda\) and \(\mathrm{or}(k)\to L_k\) not implemented, `volOrderToMintPlan` builds one envelope chunk.

## Linked issue
Solves #36 (docs half; `feat` half — four \(\ell_k\) chunks + \(\Lambda\) — remains open)

## Test plan
- [ ] Math review of the three-piece \(\pi^\varphi(\ell;p_{1/2})\) against Uniswap V3 amounts
- [ ] Follow-up: Haskell test `fromLegs` (Hop B) vs 4-leg \(\sum_k\) built from `CLMMPosition` / chunk form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULfhs3u6dy5tjf5UaoS6GG