### PR TITLE
chore(todo-25): mark docs half merged via #38; restore #19/#23 notes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -89,11 +89,14 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - Depends on #17
    - No GitHub issue yet
 
-19. **Exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\)** — `feat`
+19. **Exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\)** — `feat` — **split spine Lane B** (Option 3, 2026-08-23)
    - **MUST** keep this symbol / spelling in code, tests, issues, and docs
+   - Type: `TransactionalReturn` (not `TransactionalExpectedReturn` — avoids conflating return with MEV \(r^{\phi}\) or fee price)
+   - Evaluator: `runTransSwapAlongTenorMixture`; leg blend \(w\) documented as implementation device only
    - Orthogonal to directional price moves; volatility-measured (arbs not directional)
    - Cite MEV note for motivation only — **never** adopt its \(\Delta\pi_{\mathrm{trans}}\) naming
-   - Decide: first-class return type vs notes-only scalar control
+   - Lane A (\(\delta_{\mathrm{trans}}\), \(r^{\phi}=\phi\cdot\delta_{\mathrm{trans}}\)) is Slice 2 / #7; bridge \(r_{\mathrm{trans}}^{e}\leftrightarrow\delta^{\star}\) via #23 golden paths
+   - Spec: `docs/superpowers/specs/2026-08-22-scratchpad-rarb-trans-flow-design.md` §1b, §2
    - No GitHub issue yet
 
 20. **\(\sigma_{IV}\) stand-in** — `feat`
@@ -120,7 +123,7 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - Shock: \(V=\bar L e^u\), \(\delta^\*\) → `volTgtWad`, `txlVolumeRate`; \(u=\ln(V/\bar L)=\ln\kappa\) at prover boundary
    - Derive \(\nu_{\mathrm{trans}}=\sum\sqrt{\bar p|\Delta Q_X\Delta Q_M|}\) from JSON `dQx`/`dQM`; \(g=\nu_{\mathrm{trans}}/V\)
    - Golden table \(g(\delta^\*,\kappa,\bar\phi,\ldots)\) from GAMS grid (`make test-gams`); option A (exogenous \(\nu\)) **pre-prover stub only**
-   - Prereq for #7 \(\delta_{\mathrm{trans}}=\nu_{\mathrm{trans}}/\pi_{\mathrm{trans}}^{\Delta Q}\) beyond stub; complements RARB Slice 1 (#19 trans tag)
+   - Prereq for #7 \(\delta_{\mathrm{trans}}=\nu_{\mathrm{trans}}/\pi_{\mathrm{trans}}^{\Delta Q}\) beyond stub; complements RARB Slice 1 Lane B (#19 `TransactionalReturn`)
    - Reads: `refs/volume_path.gms`, `refs/VOLUME_PATH.md`, `refs/MEV_TAX_MODEL_ONE_NOTES.md`
 
 24. **\(\pi^{\varphi}=\pi^{\phi}-\pi^{\mathrm{LVR}}\) decomposition** — `docs`→`feat` — [#35](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/35)

--- a/TODO.md
+++ b/TODO.md
@@ -129,13 +129,14 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - \(\pi^{\mathrm{arb}}\equiv\pi_{\mathrm{arb}}^{\Delta Q}\) (#21); LVR = normalized return read off arb leg; \(r^{\varphi}=r^{\phi}-r^{\mathrm{LVR}}\)
    - Depends: RARB trans tag (#19), arb mixture (#21); CLMM identity test vs `CLMMPosition`
 
-25. **\(\pi^{\sigma}=f(\pi^{\varphi})\) — Panoptic/Haskell bridge (not MEV Σ)** — `docs`→`feat` — [#36](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/36)
+25. **\(\pi^{\sigma}=f(\pi^{\varphi})\) — Panoptic/Haskell bridge (not MEV Σ)** — ~~`docs`~~→`feat` — [#36](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/36) / docs half merged [#38](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/38) (2026-08-23)
    - **Ground truth:** shipped Hop A/B — \(\pi^{\sigma}=\Delta Q_{v}\cdot\Pi^{\sigma}_{\mathrm{opt}}\) with
      \(\Pi^{\sigma}_{\mathrm{opt}}=N_{\mathrm{id}}\bigl((P-P^{\star})/P^{\star}-\ln(P/P^{\star})\bigr)+R\) (`VariancePortfolio` / `MintPlan` → `targetVegaFromMint`)
-   - **Open:** identify how \(\pi^{\varphi}\) (CLMM / fee−LVR, #24) enters \(\Pi_{\mathrm{opt}}\) / \(R\) / the book — board claim \(\pi^{\sigma}=f(\pi^{\varphi})\); MEV \(\sum L(i)\pi^{\varphi}(i)\) is **not** ground truth
+   - ~~**Open:** identify how \(\pi^{\varphi}\) enters \(\Pi_{\mathrm{opt}}\) / \(R\) / the book~~ **Pinned (README, #38):** \(\hat\pi^{\sigma}\equiv\sum_{k=0}^{3}[\pi^{\varphi}(\ell_k;p^\star)-\pi^{\varphi}(\ell_k;p)]\), \(\ell_k=(i_k^-,i_k^+,L_k)\), \(L_k=\Lambda(i_k^-,i_k^+;\mathrm{or}(k)\Delta Q_\upsilon)\); \(\pi^{\varphi}(\ell;p_{1/2})\) = Uniswap V3 position value. Hop A/B \(F-\mathrm{Log}\) = continuum-limit remark; MEV \(\sum L(i)\pi^{\varphi}(i)\) = short side, **not** ground truth
+   - **`feat` open:** (a) `volOrderToMintPlan` → four \(\ell_k\) chunks (now one envelope chunk); (b) \(\Lambda\) amount→liquidity and \(\mathrm{or}(k)\to L_k\) (`OptionRatio.hs` TODO); (c) test Hop B `fromLegs` vs 4-leg chunk sum; (d) CLMM normalization \(c(\kappa,r)\) vs `CLMMPosition` — blocked on #24
    - Spec pointer: `cfmm-theory/docs/superpowers/specs/2026-08-19-scratchpad-target-vega-replication-design.md` (≡^R OPEN); roadmap roles doc
    - Depends: #24 (net \(\pi^{\varphi}\)); uses existing `VariancePortfolio` / `CLMMPosition`
-   - Deliverable: design note pinning \(f\) from Haskell; then code/tests if warranted
+   - Deliverable: ~~design note pinning \(f\) from Haskell~~ (#38); then code/tests (a)–(d)
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 


### PR DESCRIPTION
## Summary
- TODO #25: `docs` half struck through, links PR #38; pins \(\hat\pi^\sigma\) definition inline; enumerates remaining `feat` items (a)–(d)
- TODO #19: restores split-spine Lane B notes (`TransactionalReturn`, evaluator, Lane A cross-ref, spec pointer); #23 cross-ref updated — these were uncommitted working-tree edits lost to a `reset --hard` and reconstructed from the captured diff

## Linked issue
Status update for #36 (not closing — `feat` half open)

## Test plan
- [ ] Read-through of TODO #19 / #25 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULfhs3u6dy5tjf5UaoS6GG