### PR TITLE
docs(todo-21): define r^e_arb ≡ Λ(γ(u − u*(σ^e)))

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,19 @@ u^\star(t)=2\ln\!\Big(\frac{\sigma \, (t)}{2\phi(\,;\sigma \, (t))}\Big).
 \]
 
 
+Parametric arb return (TODO #21): the \([0,1]\) measure of \(\sigma/\phi\) — vol gained per unit of markup paid, \(\sigma_{\mathrm{IV}}/\phi = 2e^{u/2}\) — through the anchor's sigmoid \(\Lambda\) (VOLATILITY_INSTRUMENTS), evaluated at \(\sigma^{e}\):
+
+\[
+	\begin{aligned}
+		r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{\mathrm{IV}}, \sigma^{e}) \, &\equiv \, \Lambda\big(\gamma \, (u - u^{\star}(\sigma^{e}))\big), \qquad
+		u^{\star}(\sigma^{e}) = 2\ln\!\Big(\frac{\sigma^{e}}{2\phi}\Big) \\[4pt]
+		&= \, \Lambda\Big(2\gamma \, \ln \frac{\sigma_{\mathrm{IV}}}{\sigma^{e}}\Big) \qquad \text{(since } \sigma_{\mathrm{IV}} = 2\phi e^{u/2}\text{)}
+	\end{aligned}
+\]
+
+\(= \tfrac12\) at \(u = u^{\star}\) (state IV-consistent); \(\to 1\) when volume/liquidity implies more vol than the markup prices (arb-rich); \(\to 0\) when the markup over-prices it. \(\gamma\) is the single free scale (absorbs \(\sqrt{\Delta t}\)). Increasing in \(\phi\) at fixed \(\sigma^{e}\) — this is the **vol-gap** channel of the arb swap leg; LVR accrual (price-arb band crossing, \(\sigma\sqrt{\Delta t}/\phi\)) is **decreasing** in \(\phi\), so \(\beta\) (arb-leg weight, #22) and \(1-g\) (realized arb volume share) remain distinct parameters. Splitter: \((r^{e}, \beta)\) ex-ante, \((r^{e}, 1-g)\) ex-post; orthogonality \(\partial\pi^{\phi}/\partial\beta = 0\), \(\partial\pi^{\mathrm{LVR}}/\partial r^{e} = 0\) (Aristotle claim, #35-style).
+
+
 geometry:
 
 Lattice \(\kappa_j = j/N\), \(N=255\) — **encoding C**: `KappaTick` / `KappaSpacing`; B (`KappaPips`) retired. Def 45 `kappaAt (Maybe EtaX96) XiX96 LiquidityChunk` → `KappaCoordinate`.

--- a/TODO.md
+++ b/TODO.md
@@ -109,6 +109,8 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - \(\sigma^{e}\) = risk-neutral expectation of realized vol (`ExpectedVolatility` + `VolHorizon`: WINDOW \| tenor); spec `docs/superpowers/specs/2026-08-22-scratchpad-expected-volatility-design.md`
    - **Slice 1 merged (PR #33):** `ExpectedVolatility` uniform tenor + window stub, minimal `ImpliedVolatility`, `volGap`
    - Remaining: Slice 2+; arb gap \(g(\cdot)\); full \(\mathbb{E}^{\mathbb{Q}}\) via #17–#18
+   - **Definition pinned (README, 2026-08-23):** \(r_{\Delta Q_{\mathrm{arb}}}^{e}\equiv\Lambda(\gamma(u-u^{\star}(\sigma^{e})))=\Lambda(2\gamma\ln(\sigma_{IV}/\sigma^{e}))\), \(u^{\star}=2\ln(\sigma^{e}/2\phi)\); \(\Lambda\) = anchor sigmoid; \(\gamma\) free scale. Vol-gap channel (↑ in \(\phi\)); LVR band-crossing ↓ in \(\phi\) ⇒ \(\beta\) and \(1-g\) stay distinct
+   - `feat`: `ImpliedVolatility`/`ExpectedVolatility` → \(u^{\star}\) → `volGap` → \(\Lambda\) (reuse `AdaptiveStremia` sigmoid); orthogonality lemma to Aristotle alongside #35
    - Depends on #20; **#22** (\(\beta\)) before compose
 
 22. **Understand \(\beta\) in the \(r_{\Delta Q}^{e}\) affine split** — `docs` — [#28](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/28)


### PR DESCRIPTION
## Summary
- README (after the \(u^\star\) identity): \(r^e_{\Delta Q_{\mathrm{arb}}}(\sigma_{IV},\sigma^e)\equiv\Lambda(\gamma(u-u^\star(\sigma^e)))=\Lambda(2\gamma\ln(\sigma_{IV}/\sigma^e))\) — the \([0,1]\) measure of \(\sigma/\phi\) (vol gained per unit markup), \(\Lambda\) = anchor sigmoid, \(\gamma\) free scale
- Sign note: vol-gap channel ↑ in \(\phi\), LVR band-crossing ↓ in \(\phi\) ⇒ \(\beta\) and \(1-g\) stay distinct; splitter \((r^e,\beta)\)/\((r^e,1-g)\); orthogonality claim queued for Aristotle
- TODO #21: definition pinned, `feat` path listed

## Linked issue
Advances #31 (docs); relates to #28 (β)

## Test plan
- [ ] Read-through README RARB block and TODO #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULfhs3u6dy5tjf5UaoS6GG