### PR TITLE
docs(todo-23): [ν_trans/ν] atomic share replaces g

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,12 +347,12 @@ Weights in (RARB), both in \([0,1]\):
 	\begin{aligned}
 		\partial_{(r_{\Delta Q_{\mathrm{trans}}}^{e},\, r_{\Delta Q_{\mathrm{arb}}}^{e})} \, &\equiv \, \frac{\partial \, r_{\Delta Q}^{e}}{\partial \, r_{\Delta Q_{\mathrm{arb}}}^{e}}\bigg|_{r_{\Delta Q_{\mathrm{trans}}}^{e}}
 		\qquad \text{(ex-ante weight of the arb leg in the net-swap return; TODO \#22 — a definition by role, its formula is the open item)} \\[4pt]
-		g \, &\equiv \, \frac{\nu_{\mathrm{trans}}}{V}, \qquad V = L(i(t))\,e^{u(t)}, \qquad 1 - g = \frac{\nu_{\mathrm{arb}}}{V}
-		\qquad \text{(ex-post transactional share of volume; `refs/volume_path.gms`, TODO \#23)}
+		\Big[\tfrac{\nu_{\mathrm{trans}}}{\nu}\Big] \, &\in [0,1], \qquad 1 - \Big[\tfrac{\nu_{\mathrm{trans}}}{\nu}\Big] = \frac{\nu_{\mathrm{arb}}}{\nu}
+		\qquad \text{(ex-post transactional share of volume, an \textbf{atomic given value} — brackets mean it is read, not computed as a ratio; `refs/volume_path.gms`, TODO \#23)}
 	\end{aligned}
 \]
 
-\(\partial_{(r_{\Delta Q_{\mathrm{trans}}}^{e},\, r_{\Delta Q_{\mathrm{arb}}}^{e})}\) is the ex-ante counterpart of the realized \(1-g\). Note \(g \ne \delta_{\mathrm{trans}}\): \(g = \nu_{\mathrm{trans}}/V\) is a share of total volume, \(\delta_{\mathrm{trans}} = \nu_{\mathrm{trans}}/\pi^{\Delta Q}_{\mathrm{trans}}\) is turnover of the transactional leg; they are linked by \(g = \delta_{\mathrm{trans}}\,\pi^{\Delta Q}_{\mathrm{trans}}/V\), and only \(g\) carries the trans/arb split.
+\(\partial_{(r_{\Delta Q_{\mathrm{trans}}}^{e},\, r_{\Delta Q_{\mathrm{arb}}}^{e})}\) is the ex-ante counterpart of the realized \(1-\Big[\tfrac{\nu_{\mathrm{trans}}}{\nu}\Big]\). Note \Big[\tfrac{\nu_{\mathrm{trans}}}{\nu}\Big] \(\ne \delta_{\mathrm{trans}}\): the bracket is a share of total volume, \(\delta_{\mathrm{trans}} = \nu_{\mathrm{trans}}/\pi^{\Delta Q}_{\mathrm{trans}}\) is turnover of the transactional leg; only the bracket carries the trans/arb split.
 
 Parametric arb return (TODO #21): the \([0,1]\) measure of \(\sigma/\phi\) — vol gained per unit of markup paid, \(\sigma_{\mathrm{IV}}/\phi = 2e^{u/2}\) — through the anchor's sigmoid \(\Lambda\) (VOLATILITY_INSTRUMENTS), evaluated at \(\sigma^{e}\):
 
@@ -364,7 +364,7 @@ Parametric arb return (TODO #21): the \([0,1]\) measure of \(\sigma/\phi\) — v
 	\end{aligned}
 \]
 
-\(= \tfrac12\) at \(u = u^{\star}\) (state IV-consistent); \(\to 1\) when volume/liquidity implies more vol than the markup prices (arb-rich); \(\to 0\) when the markup over-prices it. \(\gamma\) is the single free scale (absorbs \(\sqrt{\Delta t}\)). Increasing in \(\phi\) at fixed \(\sigma^{e}\) — this is the **vol-gap** channel of the arb swap leg; LVR accrual (price-arb band crossing, \(\sigma\sqrt{\Delta t}/\phi\)) is **decreasing** in \(\phi\), so \(\partial_{(r_{\Delta Q_{\mathrm{trans}}}^{e},\, r_{\Delta Q_{\mathrm{arb}}}^{e})}\) (arb-leg weight, #22) and \(1-g\) (realized arb volume share) remain distinct parameters. Splitter: \((r^{e}, \partial_{(r_{\Delta Q_{\mathrm{trans}}}^{e},\, r_{\Delta Q_{\mathrm{arb}}}^{e})})\) ex-ante, \((r^{e}, 1-g)\) ex-post; orthogonality \(\partial\pi^{\phi}/\partial\,\partial_{(r_{\Delta Q_{\mathrm{trans}}}^{e},\, r_{\Delta Q_{\mathrm{arb}}}^{e})} = 0\), \(\partial\pi^{\mathrm{LVR}}/\partial r^{e} = 0\) (Aristotle claim, #35-style).
+\(= \tfrac12\) at \(u = u^{\star}\) (state IV-consistent); \(\to 1\) when volume/liquidity implies more vol than the markup prices (arb-rich); \(\to 0\) when the markup over-prices it. \(\gamma\) is the single free scale (absorbs \(\sqrt{\Delta t}\)). Increasing in \(\phi\) at fixed \(\sigma^{e}\) — this is the **vol-gap** channel of the arb swap leg; LVR accrual (price-arb band crossing, \(\sigma\sqrt{\Delta t}/\phi\)) is **decreasing** in \(\phi\), so \(\partial_{(r_{\Delta Q_{\mathrm{trans}}}^{e},\, r_{\Delta Q_{\mathrm{arb}}}^{e})}\) (arb-leg weight, #22) and \(1-\Big[\tfrac{\nu_{\mathrm{trans}}}{\nu}\Big]\) (realized arb volume share) remain distinct parameters. Splitter: \((r^{e}, \partial_{(r_{\Delta Q_{\mathrm{trans}}}^{e},\, r_{\Delta Q_{\mathrm{arb}}}^{e})})\) ex-ante, \((r^{e}, 1-\Big[\tfrac{\nu_{\mathrm{trans}}}{\nu}\Big])\) ex-post; orthogonality \(\partial\pi^{\phi}/\partial\,\partial_{(r_{\Delta Q_{\mathrm{trans}}}^{e},\, r_{\Delta Q_{\mathrm{arb}}}^{e})} = 0\), \(\partial\pi^{\mathrm{LVR}}/\partial r^{e} = 0\) (Aristotle claim, #35-style).
 
 
 geometry:
@@ -395,7 +395,7 @@ Where:
 	\end{aligned}
 \]
 
-\(\nu_{\text{trans}}\) derived from `refs/volume_path.gms` (\(g=\nu_{\text{trans}}/V\)); \(\pi_{\text{trans}}^{\Delta Q}\) parametrized only by exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\).
+\(\nu_{\text{trans}}\) derived from `refs/volume_path.gms` (\Big[\tfrac{\nu_{\mathrm{trans}}}{\nu}\Big] read as an atomic given value); \(\pi_{\text{trans}}^{\Delta Q}\) parametrized only by exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\).
 
 
 Payoff decomposition (spec `docs/superpowers/specs/2026-08-22-scratchpad-pi-varphi-lvr-decomposition-design.md`; TODO #24):

--- a/TODO.md
+++ b/TODO.md
@@ -109,7 +109,7 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - \(\sigma^{e}\) = risk-neutral expectation of realized vol (`ExpectedVolatility` + `VolHorizon`: WINDOW \| tenor); spec `docs/superpowers/specs/2026-08-22-scratchpad-expected-volatility-design.md`
    - **Slice 1 merged (PR #33):** `ExpectedVolatility` uniform tenor + window stub, minimal `ImpliedVolatility`, `volGap`
    - Remaining: Slice 2+; arb gap \(g(\cdot)\); full \(\mathbb{E}^{\mathbb{Q}}\) via #17–#18
-   - **Definition pinned (README, 2026-08-23):** \(r_{\Delta Q_{\mathrm{arb}}}^{e}\equiv\Lambda(\gamma(u-u^{\star}(\sigma^{e})))=\Lambda(2\gamma\ln(\sigma_{IV}/\sigma^{e}))\), \(u^{\star}=2\ln(\sigma^{e}/2\phi)\); \(\Lambda\) = anchor sigmoid; \(\gamma\) free scale. Vol-gap channel (↑ in \(\phi\)); LVR band-crossing ↓ in \(\phi\) ⇒ \(\partial_{(r_{\mathrm{trans}}^{e},r_{\mathrm{arb}}^{e})}\) and \(1-g\) stay distinct
+   - **Definition pinned (README, 2026-08-23):** \(r_{\Delta Q_{\mathrm{arb}}}^{e}\equiv\Lambda(\gamma(u-u^{\star}(\sigma^{e})))=\Lambda(2\gamma\ln(\sigma_{IV}/\sigma^{e}))\), \(u^{\star}=2\ln(\sigma^{e}/2\phi)\); \(\Lambda\) = anchor sigmoid; \(\gamma\) free scale. Vol-gap channel (↑ in \(\phi\)); LVR band-crossing ↓ in \(\phi\) ⇒ \(\partial_{(r_{\mathrm{trans}}^{e},r_{\mathrm{arb}}^{e})}\) and \(1-\big[\nu_{\mathrm{trans}}/\nu\big]\) stay distinct
    - `feat`: `ImpliedVolatility`/`ExpectedVolatility` → \(u^{\star}\) → `volGap` → \(\Lambda\) (reuse `AdaptiveStremia` sigmoid); orthogonality lemma to Aristotle alongside #35
    - Depends on #20; **#22** (\(\beta\)) before compose
 
@@ -123,8 +123,8 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
 23. **\(\nu_{\mathrm{trans}}\) from `volume_path.gms` (prover-native \(u\leftrightarrow\nu\))** — `feat` — [#34](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/34)
    - Spec: `docs/superpowers/specs/2026-08-22-scratchpad-rarb-trans-flow-design.md` §3 (option **B** approved)
    - Shock: \(V=\bar L e^u\), \(\delta^\*\) → `volTgtWad`, `txlVolumeRate`; \(u=\ln(V/\bar L)=\ln\kappa\) at prover boundary
-   - Derive \(\nu_{\mathrm{trans}}=\sum\sqrt{\bar p|\Delta Q_X\Delta Q_M|}\) from JSON `dQx`/`dQM`; \(g=\nu_{\mathrm{trans}}/V\)
-   - Golden table \(g(\delta^\*,\kappa,\bar\phi,\ldots)\) from GAMS grid (`make test-gams`); option A (exogenous \(\nu\)) **pre-prover stub only**
+   - Derive \(\nu_{\mathrm{trans}}=\sum\sqrt{\bar p|\Delta Q_X\Delta Q_M|}\) from JSON `dQx`/`dQM`; \(\big[\nu_{\mathrm{trans}}/\nu\big]\) read as an atomic given value (not a computed ratio)
+   - Golden table \(\big[\nu_{\mathrm{trans}}/\nu\big](\delta^\*,\kappa,\bar\phi,\ldots)\) from GAMS grid (`make test-gams`); option A (exogenous \(\nu\)) **pre-prover stub only**
    - Prereq for #7 \(\delta_{\mathrm{trans}}=\nu_{\mathrm{trans}}/\pi_{\mathrm{trans}}^{\Delta Q}\) beyond stub; complements RARB Slice 1 Lane B (#19 `TransactionalReturn`)
    - Reads: `refs/volume_path.gms`, `refs/VOLUME_PATH.md`, `refs/MEV_TAX_MODEL_ONE_NOTES.md`
 


### PR DESCRIPTION
## Summary
- Replaces \(g\) by \(\big[\nu_{\mathrm{trans}}/\nu\big]\) in README RARB block and TODO #21/#23; brackets mark an atomic given value (read from state, not computed as a ratio)
- Arb share is \(1-\big[\nu_{\mathrm{trans}}/\nu\big]\); \(\delta_{\mathrm{trans}}\) note kept

## Linked issue
Relates to #28, #31 (TODO #23 has no issue yet)

## Test plan
- [ ] grep: no `1-g` / `(g=` in README/TODO

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULfhs3u6dy5tjf5UaoS6GG