### PR TITLE
docs: LVR connector rate-only — r^LVR = [ν_arb/ν] λ_ARB(u,φ;LC_leg)

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,11 +388,13 @@ Objective (anchor \(e^{\sigma} = |\pi^{\sigma} - \hat{\pi^{\sigma}}|\)): \(\pi^{
 
 \]
 
-LVR connector — volume share only. LVR per unit of arb volume is the price gap captured crossing the fee band, a function of \(\sigma\sqrt{\Delta t}/\phi\) and the chunk geometry, not of which token the arb delivers; with the anchor's per-unit \(\lambda_{\mathrm{ARB}}\):
+LVR connector — volume share only, rate-only (no level \(\nu\) is observed in this model; only \(u = \ln(V/L)\), the atomic shares, and returns). LVR per unit of arb share is the price gap captured crossing the fee band; its vol-over-fee argument is read from state as \(\sigma_{\mathrm{IV}}/\phi = 2e^{u/2}\), so it is a function of \((u, \phi)\) and the chunk geometry, not of which token the arb delivers. With the anchor's \(\lambda_{\mathrm{ARB}}\) as a return and the MEV normalizer \(\mathcal{N}_\pi\):
 
 \[
 	\begin{aligned}
-		\pi^{\mathrm{LVR}}(\mathcal{LC}_{\mathrm{leg}}) \, &= \, \Big[\tfrac{\nu_{\mathrm{arb}}}{\nu}\Big] \, \nu \, \lambda_{\mathrm{ARB}}\big(\sigma\sqrt{\Delta t}/\phi;\, \mathcal{LC}_{\mathrm{leg}}\big)
+		r^{\mathrm{LVR}}(\mathcal{LC}_{\mathrm{leg}}) \, &= \, \Big[\tfrac{\nu_{\mathrm{arb}}}{\nu}\Big] \, \lambda_{\mathrm{ARB}}\big(u, \phi;\, \mathcal{LC}_{\mathrm{leg}}\big), \qquad
+		\pi^{\mathrm{LVR}} \, = \, \mathcal{N}_\pi^{-1} \, r^{\mathrm{LVR}}, \qquad
+		r^{\varphi} \, = \, r^{\phi} - r^{\mathrm{LVR}}
 	\end{aligned}
 \]
 


### PR DESCRIPTION
## Summary
- Removes the unobserved level \(\nu\) from the LVR connector: \(r^{\mathrm{LVR}}(\mathcal{LC}_{\mathrm{leg}})=[\nu_{\mathrm{arb}}/\nu]\,\lambda_{\mathrm{ARB}}(u,\phi;\mathcal{LC}_{\mathrm{leg}})\), \(\pi^{\mathrm{LVR}}=\mathcal N_\pi^{-1}r^{\mathrm{LVR}}\), \(r^\varphi=r^\phi-r^{\mathrm{LVR}}\)
- \(\sigma\sqrt{\Delta t}/\phi\) replaced by the observed state via \(\sigma_{IV}/\phi=2e^{u/2}\)

## Linked issue
Relates to #31, #35

## Test plan
- [ ] grep: no `\nu \, \lambda_{\mathrm{ARB}}` in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULfhs3u6dy5tjf5UaoS6GG