### PR TITLE
feat(todo-24): per-tick CLMM identity proved — Payoffs.ChunkPrincipal + witness

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ And the option-replica volatility payoff is the **4-leg Panoptic position**
 		\mathcal{LC} \, &\equiv \, (i^{-}, \, i^{+}, \, L), \qquad i^{-} < i^{+}, \quad 0 < L < 2^{128}, \qquad
 		p_{1/2}(i) \, \equiv \, 1.0001^{\,i/2}, \quad p_{1/2}^{(\mathrm{bid})} \equiv p_{1/2}(i^{-}), \; p_{1/2}^{(\mathrm{ask})} \equiv p_{1/2}(i^{+}) \\
 		k_{1/2}(i^{-}, i^{+}) \, &\equiv \, \sqrt{p_{1/2}^{(\mathrm{bid})} \, p_{1/2}^{(\mathrm{ask})}}, \qquad
-		r(i^{-}, i^{+}) \, \equiv \, \frac{p^{(\mathrm{ask})}}{p^{(\mathrm{bid})}} \, = \, 1.0001^{\,i^{+} - i^{-}}
+		r(i^{-}, i^{+}) \, \equiv \, \frac{p_{1/2}^{(\mathrm{ask})}}{p_{1/2}^{(\mathrm{bid})}} \, = \, 1.0001^{\,(i^{+} - i^{-})/2} \qquad \text{(sqrt-price ratio — the } r \text{ of } \pi^{\mathrm{RAN}}\text{)}
 	\end{aligned}
 \]
 
@@ -114,16 +114,16 @@ Unit chunk at tick \(i\) (tick spacing \(\Delta_i\); units handled on the EVM di
 	\begin{aligned}
 		\ell(\ell_{\mathcal{G}}, \omega;\, i) \, &\equiv \, \sum_{g} \omega_g \, \ell_{\mathcal{G}}(\iota_g;\, i \mid \xi^{\star}), \qquad \omega_g \ge 0, \; \sum_g \omega_g = 1, \quad \ell(i) \ge 0, \; \sum_i \ell(i) = 1
 	\end{aligned}
-\]
-
+CLMM identity (TODO #24 / #35, `CLMMPosition`) — **proved** (closed form, 2026-08-23; Haskell witness `Payoffs.ChunkPrincipal` + `test/Spec.hs`), exact for every \(p_{1/2}\) below, inside and above the range:
 
 \[
 	\begin{aligned}
-		\pi^{\varphi}\big(\mathrm{Id}_i[\mathcal{LC}];\, p_{1/2}\big) \, &\overset{?}{=} \, L_{\Delta_i} \, \Big[ \pi^{c|p}\big(k_{1/2}(i, i+\Delta_i)\big) + \pi^{\mathrm{RAN}}\big(k_{1/2}(i, i+\Delta_i), \, r(i, i+\Delta_i)\big) \Big]
+		\pi^{\varphi}\big(\mathrm{Id}_i[\mathcal{LC}];\, p_{1/2}\big) \, &= \, \mathrm{amount}_0\big(\mathrm{Id}_i[\mathcal{LC}]\big) \, \Big[ \pi^{c|p}\big(k_{1/2}(i, i+\Delta_i)\big) + \pi^{\mathrm{RAN}}\big(k_{1/2}(i, i+\Delta_i), \, r(i, i+\Delta_i)\big) \Big] \\[4pt]
+		\mathrm{amount}_0\big(\mathrm{Id}_i[\mathcal{LC}]\big) \, &= \, 1e18 \, \Big( \frac{1}{p_{1/2}^{(\mathrm{bid})}} - \frac{1}{p_{1/2}^{(\mathrm{ask})}} \Big)
 	\end{aligned}
 \]
 
-> DESIGN CLAIM — to be proved (Aristotle / Lean), not asserted. \(L_{\Delta_i}\) is a single liquidity constant per tick spacing (not a function of the range), which is the whole content of the claim; if it fails, the `CLMMPosition` unit payoff and the Uniswap unit payoff differ by more than scale and #24's CLMM identity test is the place that surfaces it. The entry point is the full \(\pi^{c|p} + \pi^{\mathrm{RAN}}\), **not** \(\pi^{c|p}\) alone: \(\pi^{c|p} = \min(P, K)\) is width-blind; width enters only through \(\pi^{\mathrm{RAN}}\).
+Proof sketch: with \(a = p^{(\mathrm{bid})}_{1/2}\), \(b = p^{(\mathrm{ask})}_{1/2}\), \(k_{1/2}\sqrt r = b\), \(k_{1/2}^2 = ab\), both RAN arms reduce to \((2pb - p^2 - ab)/(r-1)\) while the in-range principal is \((2pb - p^2 - ab)/b\); below range both are \(\propto p^2\); above, \(b - a\) vs \(ab\). The ratio is \(1/a - 1/b\) in all three pieces. So the normalization is the unit chunk's **token0 amount** (`getAmount0ForLiquidity`), a function of \((i, \Delta_i)\) — **not** one constant per tick spacing as first claimed — and `CLMMPosition` is the LP payoff per unit of token0 notional. The identity requires \(r\) to be the sqrt-price ratio (fixed above). The entry point is the full \(\pi^{c|p} + \pi^{\mathrm{RAN}}\), **not** \(\pi^{c|p}\) alone: \(\pi^{c|p} = \min(P, K)\) is width-blind; width enters only through \(\pi^{\mathrm{RAN}}\). Aristotle transcription still owed (#35, gated on the Lean workspace) — the hand proof is elementary algebra on three pieces.
 
 **Leg geometry** (`Volatility.VolOrder.legIntervals`): from \((i_L, i_U)\) (width/skew about \(i^{\star}\), `tickBucketFromVolOrder`) and split points \(m_P, m_C\) (`volOrderSplitPoints`):
 

--- a/TODO.md
+++ b/TODO.md
@@ -148,6 +148,7 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - \(\pi^{c|p}+\pi^{\mathrm{RAN}}\equiv\pi^{\varphi}\) (CLMM); \(\pi^{\varphi}=\pi^{\phi}(\pi_{\mathrm{trans}}^{\Delta Q})-\pi^{\mathrm{LVR}}(\pi_{\mathrm{arb}}^{\Delta Q})\)
    - \(\pi^{\mathrm{arb}}\equiv\pi_{\mathrm{arb}}^{\Delta Q}\) (#21); LVR = normalized return read off arb leg; \(r^{\varphi}=r^{\phi}-r^{\mathrm{LVR}}\)
    - Depends: RARB trans tag (#19), arb mixture (#21); CLMM identity test vs `CLMMPosition`
+   - **CLMM identity PROVED (2026-08-23):** \(\pi^{\varphi}(\mathrm{Id}_i[\mathcal{LC}];p)=\mathrm{amount}_0(\mathrm{Id}_i)\,[\pi^{c|p}+\pi^{\mathrm{RAN}}](p)\), \(r\) = sqrt-price ratio; normalization per \((i,\Delta_i)\) not per \(\Delta_i\). `Payoffs.ChunkPrincipal` + witness test. Remaining: \(\chi(\mathcal{LC})\) definition for #26; Aristotle transcription
 
 25. **\(\pi^{\sigma}=f(\pi^{\varphi})\) — Panoptic/Haskell bridge (not MEV Σ)** — ~~`docs`~~→`feat` — [#36](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/36) / docs half merged [#38](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/38) (2026-08-23)
    - **Ground truth:** shipped Hop A/B — \(\pi^{\sigma}=\Delta Q_{v}\cdot\Pi^{\sigma}_{\mathrm{opt}}\) with

--- a/cfmm-scratchpad.cabal
+++ b/cfmm-scratchpad.cabal
@@ -38,6 +38,7 @@ library
       Panoptic.MintPlan
       Panoptic.NId
       Payoffs.CashSecuredPut
+      Payoffs.ChunkPrincipal
       Payoffs.CLMMPosition
       Payoffs.CoveredCall
       Payoffs.Forward

--- a/src/Payoffs/ChunkPrincipal.hs
+++ b/src/Payoffs/ChunkPrincipal.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+-- | π^φ of a liquidity chunk: the Uniswap V3 position PRINCIPAL valued in
+-- token1 at sqrt-price p½ (README "π^φ of a chunk", three-piece form;
+-- = v3-periphery PositionValue.principal, amount0·P + amount1).
+--
+-- Per-tick CLMM identity (README MODEL_CLOSURE, TODO #24 / #35):
+--
+--   chunkPrincipal (unitChunk i Δ) p
+--     = chunkAmount0 (unitChunk i Δ) · [π^{c|p}(k½) + π^RAN(k½, r)](p) / Q96
+--
+-- with k½ = √(p^bid p^ask) and r = p^ask/p^bid the SQRT-price ratio.  The
+-- normalization is the unit chunk's token0 amount — it depends on (i, Δ_i),
+-- not on Δ_i alone.  Witness test in test/Spec.hs.
+module Payoffs.ChunkPrincipal
+  ( chunkPrincipal
+  , chunkAmount0
+  , chunkAmount1
+  , unitChunk
+  , unitLiquidity
+  ) where
+
+import Liquidity.LiquidityChunk
+  ( LiquidityChunk
+  , chunkLiquidity
+  , chunkTickLower
+  , chunkTickUpper
+  , createChunk
+  )
+import SqrtGrid
+  ( PayoffX96(..)
+  , SqrtPriceX96(..)
+  , Tick
+  , TickSpacing
+  , pattern Q96
+  , sqrtPriceX96
+  , unTickSpacing
+  )
+
+-- | Id_i[𝓛𝓒] ≡ (i, i + Δ_i, 1e18): units handled on the EVM, 1e18 = one unit of L.
+unitLiquidity :: Integer
+unitLiquidity = 10 ^ (18 :: Int)
+
+unitChunk :: Tick -> TickSpacing -> LiquidityChunk
+unitChunk i spacing = createChunk i (i + unTickSpacing spacing) unitLiquidity
+
+bounds :: LiquidityChunk -> (Integer, Integer, Integer)
+bounds ch =
+  let SqrtPriceX96 a = sqrtPriceX96 (chunkTickLower ch)
+      SqrtPriceX96 b = sqrtPriceX96 (chunkTickUpper ch)
+  in  (a, b, chunkLiquidity ch)
+
+-- | token0 amount of the whole chunk when price is at/below p^bid:
+--   L · (1/a − 1/b) = L · (b − a) · Q96 / (a · b)   (LiquidityAmounts.getAmount0ForLiquidity)
+chunkAmount0 :: LiquidityChunk -> PayoffX96
+chunkAmount0 ch =
+  let (a, b, l) = bounds ch
+  in  PayoffX96 $ (l * (b - a) * Q96) `div` (a * b)
+
+-- | token1 amount of the whole chunk when price is at/above p^ask:
+--   L · (b − a)   (LiquidityAmounts.getAmount1ForLiquidity)
+chunkAmount1 :: LiquidityChunk -> PayoffX96
+chunkAmount1 ch =
+  let (a, b, l) = bounds ch
+  in  PayoffX96 $ (l * (b - a)) `div` Q96
+
+-- | Principal valued in token1 at sqrt-price p (all quantities Q96-scaled):
+--   p < a      : L · p² · (1/a − 1/b)
+--   a ≤ p < b  : L · (2p − a − p²/b)
+--   p ≥ b      : L · (b − a)
+chunkPrincipal :: LiquidityChunk -> SqrtPriceX96 -> PayoffX96
+chunkPrincipal ch (SqrtPriceX96 p)
+  | p < a     = PayoffX96 $ (l * p * p * (b - a)) `div` (a * b) `div` Q96
+  | p < b     = PayoffX96 $ (l * (2 * p - a - (p * p) `div` b)) `div` Q96
+  | otherwise = PayoffX96 $ (l * (b - a)) `div` Q96
+  where
+    (a, b, l) = bounds ch

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -203,6 +203,8 @@ import SqrtGrid
   )
 import State (pattern SQRT_PRICE_1_4, pattern SQRT_PRICE_4_1)
 import StrikeX96 (StrikeX96(..))
+import qualified Payoffs.CLMMPosition as CLMM
+import Payoffs.ChunkPrincipal (chunkPrincipal, chunkAmount0, unitChunk)
 import Data.Vector ((!))
 import qualified Data.Vector as V
 import TickPath (TickPath(..), mkTickPath, pathLength, ticks)
@@ -887,6 +889,34 @@ main = do
       hopBIota
     )
   putStrLn "ok: hop B Π vs-gamma / vs-xi layouts"
+
+  -- TODO #24 / #35: per-tick CLMM identity (README MODEL_CLOSURE, 2026-08-23).
+  -- π^φ(Id_i[𝓛𝓒]; p) = amount0(Id_i) · [π^{c|p}(k½) + π^RAN(k½, r)] exactly,
+  -- with k½ = √(p^bid p^ask), r = p^ask/p^bid the SQRT-price ratio
+  -- (= 1.0001^{Δ_i/2}), for every p below / in / above the range.
+  -- The constant is the unit chunk's token0 amount — per (i, Δ_i), not per Δ_i.
+  let identityAt i di p =
+        let ch   = unitChunk i (mkTickSpacing di)
+            SqrtPriceX96 a = sqrtPriceX96 i
+            SqrtPriceX96 b = sqrtPriceX96 (i + di)
+            kRaw = floor (sqrt (fromInteger a * fromInteger b :: Double)) :: Integer
+            r    = fromInteger b / fromInteger a :: Double
+            clmm = CLMM.toPayoff (CLMM.fromCall (StrikeX96 kRaw) (OptionRatio r))
+            PayoffX96 lhs = chunkPrincipal ch p
+            PayoffX96 c   = Payoff.runPayoff clmm p
+            PayoffX96 am0 = chunkAmount0 ch
+            rhs  = (am0 * c) `div` Q96
+            tol  = max 1 (abs rhs `div` 1000000)  -- 1e-6 rel; X96 floors
+        in  if abs (lhs - rhs) <= tol
+              then pure ()
+              else error ("CLMM identity fails at i=" ++ show i ++ " Δ=" ++ show di
+                          ++ " p=" ++ show p ++ ": lhs=" ++ show lhs ++ " rhs=" ++ show rhs)
+  sequence_
+    [ identityAt i di (sqrtPriceX96 (i + off))
+    | (i, di) <- [(0, 10), (0, 60), (-3000, 200), (40000, 10), (-120000, 60)]
+    , off <- [-di, -1, 0, 1, di `div` 2, di - 1, di, di + 1, 3 * di]
+    ]
+  putStrLn "ok: per-tick CLMM identity π^φ(Id_i) = amount0 · CLMMPosition"
   let
     i0 = 0 :: Tick
     i1 = 10 :: Tick


### PR DESCRIPTION
## Summary
- Implements TODO.md #24 CLMM identity test (`feat`): new `Payoffs.ChunkPrincipal` (three-piece principal = `PositionValue.principal`, `unitChunk` = \(\mathrm{Id}_i\), `chunkAmount0/1`) and a witness in `test/Spec.hs`
- **Result:** the identity is exact and closed-form — \(\pi^{\varphi}(\mathrm{Id}_i;p)=\mathrm{amount}_0(\mathrm{Id}_i)\,[\pi^{c|p}(k_{1/2})+\pi^{\mathrm{RAN}}(k_{1/2},r)](p)\) for all \(p\); the constant is the unit chunk's token0 amount, i.e. per \((i,\Delta_i)\), **not** per \(\Delta_i\) (the README claim is corrected). Requires \(r\) = sqrt-price ratio; README \(r(i^-,i^+)\) fixed accordingly
- Proof sketch in README; Aristotle transcription still owed (gated on Lean workspace)

## Linked issue
Solves #35 (identity half). Remaining on #35: \(\chi(\mathcal{LC})\) definition for #51, Aristotle transcription

## Test plan
- [x] `stack test` — `ok: per-tick CLMM identity π^φ(Id_i) = amount0 · CLMMPosition` (45 points: i∈{0,−3000,40000,−120000}, Δ∈{10,60,200}, p below/in/above)
- [ ] Aristotle statement file (later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULfhs3u6dy5tjf5UaoS6GG