### PR TITLE
fix(todo-28.0): asset bit token1 basis, integerSqrt strike, mulDiv staged forms

### DIFF
--- a/docs/BITWIDTHS.md
+++ b/docs/BITWIDTHS.md
@@ -1,0 +1,29 @@
+# Bit widths of the fixed-point chains (Solidity twin transcription table)
+
+Spec: `docs/superpowers/specs/2026-08-24-scratchpad-ladder-replication-design.md` §3, Item 0.
+Rule: every product/quotient below is written in the Haskell exactly as the Solidity twin stages it,
+using `SqrtGrid.mulDiv` (single floor; twin = 512-bit `FullMath.mulDiv`). Haskell `Integer` never
+overflows — this table is what the EVM twin must respect. Bare `a*b*c \`div\` d` is forbidden in new code.
+
+Operand ranges: sqrt prices `a, b, p` ≤ 2^160 (Q64.96); liquidity `L` ≤ 2^128; `Q96 = 2^96`;
+`amt` (or·positionSize) ≤ 127·2^128 < 2^135; rung/leg widths `b − a` < 2^160.
+
+| function | Haskell (staged) | Solidity twin | intermediate max | note |
+|---|---|---|---|---|
+| `chunkAmount0` | `mulDiv (L*Q96) (b−a) b \`div\` a` | `Math.getAmount0ForLiquidity`: `mulDiv(L << 96, b − a, b) / a` | `(L<<96)·(b−a)` ≤ 2^384 | needs 512-bit mulDiv; second `/ a` is a plain division; result cast `toUint128` (`checkU128`) |
+| `chunkAmount1` | `mulDiv L (b−a) Q96` | `Math.getAmount1ForLiquidity`: `mulDiv(L, b − a, Q96)` | `L·(b−a)` ≤ 2^288 | 512-bit mulDiv; `toUint128` |
+| `legLiquidity` (asset = 1) | `mulDiv amt Q96 (b−a)` | `Math.getLiquidityForAmount1`: `mulDiv(amt, Q96, b − a)` | `amt·Q96` ≤ 2^231 | fits 256; result `toUint128` (uint128 guard in `createChunk`) |
+| `legLiquidity` (asset = 0) | `mulDiv amt (mulDiv a b Q96) (b−a)` | `Math.getLiquidityForAmount0`: `mulDiv(amt, mulDiv96(a, b), b − a)` | `a·b` ≤ 2^320; `amt·(ab/Q96)` ≤ 2^359 | both stages 512-bit; **not** bit-equal to single `amt·a·b/((b−a)Q96)` — the staged form is canonical |
+| `legMintValue` (call) | `mulDiv (mulDiv p p Q96) am0 Q96` | two `mulDiv`s | `p²` ≤ 2^320; `(p²/Q96)·am0` ≤ 2^352 | 512-bit both stages |
+| `chunkPrincipal` in-range (via `fromChunk`) | `amount0 · [CC + RAN] / Q96` | `PositionValue.principal` (amounts at current price) | `am0·payoff` ≤ 2^128·2^224 = 2^352 | on-chain twin is the amounts route, not the CLMM identity; identity is for tests |
+| `ell` (geometric weight) | `xiPow · (Q96 − ξ) / (Q96 − ξ^ι)` (existing) | `LibGeometricDistribution.liquidityDensityX96` | ≤ 2^192 | Bunni uses `mulDiv`/`fullMulDiv` by branch; equal results at these magnitudes |
+| rung liquidity `L(i_x)` | `mulDiv ΔQ ℓ Q96` | `positionSize`-style scaling | `ΔQ·ℓ` ≤ 2^224 | fits 256 |
+| binning `n_leg` | `Σ mulDiv L_x c_x Q96`, `c_x = b_x − a_x` | off-chain / view | ≤ 2^288 per term | `positionSize = n_max / 127` must be < 2^128 → require `n_max < 2^135` |
+| `ErrorX96` | `mulDiv d Q96 N_1`, square, sum, `integerSqrt` | **off-chain only** | unbounded on-chain | no EVM bound claimed |
+| `lnQ96` (Item 1) | port of Solady `lnWad` on `mulDiv p WAD p*`, then `mulDiv (2·ln) Q96 WAD` | `FixedPointMathLib.lnWad` | int256 | signed: floor (Haskell `div`) vs truncate (Solidity `/`) — floor chosen |
+
+Rounding direction: `chunkAmount0/1` round **down**; Panoptic rounds long-closing amounts **up** (`getAmountsMoved`).
+One-wei-per-leg drift, budgeted in the X96 tolerances.
+
+Known `Double` leaks still on the path (budgeted, not claimed away): `OptionRatio` (`b/a` as `Double`, ~10 modules),
+`sqrtPriceX96` (`Double` power vs `getSqrtRatioAtTick`), `Log.nakedLogQ96` until Item 1.

--- a/src/Greeks/Delta.hs
+++ b/src/Greeks/Delta.hs
@@ -19,7 +19,8 @@ import qualified Payoffs.Payoff as Payoff
 
 import OptionRatio (OptionRatio(..))
 import SqrtGrid
-  ( SqrtPriceX96(..)
+  ( integerSqrt
+  , SqrtPriceX96(..)
   , PayoffX96(..)
   , SqrtPlot(..)
   , pattern Q96
@@ -38,14 +39,6 @@ newtype DeltaX96 = DeltaX96 Integer
 pattern DELTA_ATM :: DeltaX96
 pattern DELTA_ATM = DeltaX96 39614081257132168796771975168
 
-integerSqrt :: Integer -> Integer
-integerSqrt n
-  | n <= 0 = 0
-  | otherwise = go (1 + n `div` 2)
-  where
-    go x =
-      let x' = (x + n `div` x) `div` 2
-      in  if x' >= x then x else go x'
 
 -- (3.23) in price coordinates, then κ_{1/2} = √K · 2^96
 strikeFromDelta

--- a/src/Liquidity/LiquidityChunk.hs
+++ b/src/Liquidity/LiquidityChunk.hs
@@ -18,6 +18,7 @@ import SqrtGrid
   , SqrtPriceX96(..)
   , Tick
   , TickSpacing
+  , mulDiv
   , pattern Q96
   , sqrtPriceX96
   , unTickSpacing
@@ -82,11 +83,20 @@ sqrtBounds ch =
 chunkAmount0 :: LiquidityChunk -> PayoffX96
 chunkAmount0 ch =
   let (a, b) = sqrtBounds ch
-  in  PayoffX96 $ (chunkLiquidity ch * (b - a) * Q96) `div` (a * b)
+      -- Math.getAmount0ForLiquidity: mulDiv(L << 96, b − a, b) / a  (staged; equals floor(L(b−a)Q96/(ab)))
+      amt = mulDiv (chunkLiquidity ch * Q96) (b - a) b `div` a
+  in  PayoffX96 (checkU128 "chunkAmount0" amt)
 
 -- | token1 amount of the chunk when price is at/above p^ask:
 --   L · (b − a)   (LiquidityAmounts.getAmount1ForLiquidity)
 chunkAmount1 :: LiquidityChunk -> PayoffX96
 chunkAmount1 ch =
   let (a, b) = sqrtBounds ch
-  in  PayoffX96 $ (chunkLiquidity ch * (b - a)) `div` Q96
+      -- Math.getAmount1ForLiquidity: mulDiv(L, b − a, Q96)
+  in  PayoffX96 (checkU128 "chunkAmount1" (mulDiv (chunkLiquidity ch) (b - a) Q96))
+
+-- Panoptic casts token amounts with toUint128; mirror the bound.
+checkU128 :: String -> Integer -> Integer
+checkU128 lbl x
+  | x < 0 || x > u128Max = error ("Liquidity.LiquidityChunk." ++ lbl ++ ": amount exceeds uint128")
+  | otherwise = x

--- a/src/Panoptic/LegChunk.hs
+++ b/src/Panoptic/LegChunk.hs
@@ -5,13 +5,13 @@
 --
 -- Geometry is decoded from the tokenId bits exactly as Panoptic's asTicks:
 --   i⁻ = strike − width·Δ_i/2,  i⁺ = strike + width·Δ_i/2.
--- Size (README "Per-leg option ratio and leg chunk"): the leg notional is
--- or(leg)·ΔQ_υ, in token1 for puts (tokenType 0) and token0 for calls
--- (tokenType 1), inverted to liquidity over the leg range
--- (LiquidityAmounts.getLiquidityForAmount1 / getLiquidityForAmount0):
---
---   L_leg = or·ΔQ_υ / (p½^ask − p½^bid)              (put,  token1 notional)
---   L_leg = or·ΔQ_υ / (1/p½^bid − 1/p½^ask)          (call, token0 notional)
+-- Size: the leg notional is or(leg)·ΔQ_υ in the numeraire selected by the
+-- leg's `asset` bit — PanopticMath.getLiquidityChunk polarity:
+--   asset == 0 → getLiquidityForAmount0 (token0):  L = amt·(a·b/Q96)/(b − a)
+--   asset == 1 → getLiquidityForAmount1 (token1):  L = amt·Q96/(b − a)
+-- volOrderToTokenId sets asset = 1 on every leg (single token1 basis, spec
+-- 2026-08-24 §2), so all four legs are token1-sized. `asset` is independent
+-- of `tokenType` (which still decides the token RECEIVED at mint).
 --
 -- ΔQ_υ is the SFPM positionSize = liquidity field of the envelope 'mintChunk'
 -- (what 'targetVegaFromMint' reads).  The envelope chunk itself is NOT a leg.
@@ -26,13 +26,13 @@ module Panoptic.LegChunk
 import Liquidity.LiquidityChunk (LiquidityChunk, chunkLiquidity, createChunk)
 import Panoptic.MintPlan (MintPlan(..), PanopticTokenId, fourLegNumLegs)
 import Panoptic.NId
-  ( panopticOptionRatio
+  ( panopticAsset
+  , panopticOptionRatio
   , panopticStrike
   , panopticTickSpacing
-  , panopticTokenType
   , panopticWidth
   )
-import SqrtGrid (SqrtPriceX96(..), Tick, pattern Q96, sqrtPriceX96)
+import SqrtGrid (SqrtPriceX96(..), Tick, mulDiv, pattern Q96, sqrtPriceX96)
 
 -- | (i⁻, i⁺) of a leg, decoded from the tokenId (Panoptic asTicks).
 legTicks :: PanopticTokenId -> Int -> (Tick, Tick)
@@ -54,11 +54,11 @@ legLiquidity plan leg
       error "Panoptic.LegChunk.legLiquidity: leg out of range"
   | b <= a =
       error "Panoptic.LegChunk.legLiquidity: degenerate leg range"
-  | tokenType == 0 = (amt * Q96) `div` (b - a)              -- put:  getLiquidityForAmount1
-  | otherwise      = (amt * a * b) `div` ((b - a) * Q96)    -- call: getLiquidityForAmount0
+  | asset == 0 = mulDiv amt (mulDiv a b Q96) (b - a)   -- Math.getLiquidityForAmount0: mulDiv(amt, mulDiv96(a,b), b−a)
+  | otherwise  = mulDiv amt Q96 (b - a)                -- Math.getLiquidityForAmount1: mulDiv(amt, Q96, b−a)
   where
     tid = mintTokenId plan
-    tokenType = panopticTokenType tid (toInteger leg)
+    asset = panopticAsset tid (toInteger leg)
     amt = legNotional plan leg
     (lo, hi) = legTicks tid leg
     SqrtPriceX96 a = sqrtPriceX96 lo

--- a/src/Panoptic/NId.hs
+++ b/src/Panoptic/NId.hs
@@ -11,6 +11,7 @@ module Panoptic.NId
   , panopticTickSpacing
   , panopticOptionRatio
   , panopticIsLong
+  , panopticAsset
   , panopticTokenType
   , panopticStrike
   , panopticWidth
@@ -89,7 +90,10 @@ volOrderToTokenId vo poolId (r0, r1, r2, r3)
         tid5 = addTokenType tid4 0 1
         tid6 = addTokenType tid5 1 2
         tid7 = addTokenType tid6 1 3
-        tid8 = addIsLong tid7 1 0
+        -- asset = 1 on every leg: single token1 basis for positionSize·optionRatio
+        -- (PanopticMath.getLiquidityChunk: asset==1 → getLiquidityForAmount1). TODO #28 item 0.
+        tidA = addAsset (addAsset (addAsset (addAsset tid7 1 0) 1 1) 1 2) 1 3
+        tid8 = addIsLong tidA 1 0
         tid9 = addIsLong tid8 1 1
         tid10 = addIsLong tid9 1 2
         tid11 = addIsLong tid10 1 3
@@ -156,6 +160,11 @@ panopticOptionRatio :: PanopticTokenId -> Integer -> Integer
 panopticOptionRatio tid leg =
   shiftR (tokenId tid) (legBase leg + 1) .&. 0x7f
 
+-- | asset bit: TokenId bit 64 + 48·leg (TokenId.sol `asset`).
+panopticAsset :: PanopticTokenId -> Integer -> Integer
+panopticAsset tid leg =
+  shiftR (tokenId tid) (legBase leg) .&. 0x1
+
 panopticIsLong :: PanopticTokenId -> Integer -> Integer
 panopticIsLong tid leg =
   shiftR (tokenId tid) (legBase leg + 8) .&. 0x1
@@ -188,6 +197,10 @@ addTickSpacing tid ts = addField tid 48 0xffff ts
 addOptionRatio :: Integer -> Integer -> Integer -> Integer
 addOptionRatio tid v leg =
   addField tid (legBase leg + 1) 0x7f v
+
+addAsset :: Integer -> Integer -> Integer -> Integer
+addAsset tid v leg =
+  addField tid (legBase leg) 0x1 v
 
 addIsLong :: Integer -> Integer -> Integer -> Integer
 addIsLong tid v leg =

--- a/src/Payoffs/CLMMPosition.hs
+++ b/src/Payoffs/CLMMPosition.hs
@@ -3,6 +3,7 @@
 module Payoffs.CLMMPosition
   ( CLMMPosition
   , clmmChunk
+  , chunkStrike
   , fromChunk
   , fromCall
   , fromPut
@@ -28,6 +29,7 @@ import SqrtGrid
   ( SqrtPriceX96(..)
   , PayoffX96(..)
   , SqrtPlot
+  , integerSqrt
   , pattern Q96
   , sqrtPriceX96
   , tickFromSqrtPriceX96
@@ -63,12 +65,16 @@ data CLMMPosition = CLMMPosition
   , clmmPayoff :: Payoff.Payoff SqrtPriceX96
   }
 
+-- k½ = integerSqrt(a·b) — no Double on the strike (TODO #28 item 0).
+-- The ratio r = b/a stays an OptionRatio Double: a budgeted leak, own TODO.
 strikeAndRatio :: LiquidityChunk -> (StrikeX96, OptionRatio)
 strikeAndRatio ch =
   let SqrtPriceX96 a = sqrtPriceX96 (chunkTickLower ch)
       SqrtPriceX96 b = sqrtPriceX96 (chunkTickUpper ch)
-      kRaw = floor (sqrt (fromInteger a * fromInteger b :: Double)) :: Integer
-  in  (StrikeX96 kRaw, OptionRatio (fromInteger b / fromInteger a))
+  in  (StrikeX96 (integerSqrt (a * b)), OptionRatio (fromInteger b / fromInteger a))
+
+chunkStrike :: LiquidityChunk -> StrikeX96
+chunkStrike = fst . strikeAndRatio
 
 scaleQ96 :: PayoffX96 -> Payoff.Payoff SqrtPriceX96 -> Payoff.Payoff SqrtPriceX96
 scaleQ96 (PayoffX96 s) (Payoff.Payoff f) =

--- a/src/Payoffs/VolatilityReplica.hs
+++ b/src/Payoffs/VolatilityReplica.hs
@@ -31,7 +31,7 @@ import Panoptic.NId (panopticTokenType)
 import qualified Payoffs.CLMMPosition as CLMM
 import qualified Payoffs.Payoff as Payoff
 import Plotting.PlotSqrt (PlotY(..), sqrtFunctionLayout)
-import SqrtGrid (PayoffX96(..), SqrtPlot, SqrtPriceX96(..), pattern Q96)
+import SqrtGrid (PayoffX96(..), SqrtPlot, SqrtPriceX96(..), mulDiv, pattern Q96)
 
 -- | π^φ(𝓛𝓒_leg; p).
 legPrincipal :: LiquidityChunk -> SqrtPriceX96 -> PayoffX96
@@ -43,7 +43,7 @@ legMintValue plan leg (SqrtPriceX96 p)
   | panopticTokenType (mintTokenId plan) (toInteger leg) == 0 = chunkAmount1 ch
   | otherwise =
       let PayoffX96 am0 = chunkAmount0 ch
-      in  PayoffX96 $ ((p * p) `div` Q96 * am0) `div` Q96
+      in  PayoffX96 $ mulDiv (mulDiv p p Q96) am0 Q96   -- two mulDivs: p²/Q96 ≤ 2^224, × am0 ≤ 2^128
   where
     ch = legChunk plan leg
 

--- a/src/SqrtGrid.hs
+++ b/src/SqrtGrid.hs
@@ -22,6 +22,7 @@ module SqrtGrid
   , invX96
   , rpowX96
   , integerSqrt
+  , mulDiv
   ) where
 
 type Tick = Int
@@ -73,6 +74,15 @@ rpowX96 a n = go n a Q96
           go (k `div` 2) (mulX96 base base) (mulX96 acc base)
       | otherwise =
           go (k `div` 2) (mulX96 base base) acc
+
+-- | floor(a·b / d) — the single-floor twin of FullMath.mulDiv (512-bit
+-- intermediate on the EVM). New model arithmetic must be written as mulDiv
+-- chains in the exact staged form of the Solidity twin; bare a*b*c `div` d
+-- is forbidden (see docs/BITWIDTHS.md).
+mulDiv :: Integer -> Integer -> Integer -> Integer
+mulDiv a b d
+  | d == 0    = error "SqrtGrid.mulDiv: division by zero"
+  | otherwise = (a * b) `div` d
 
 integerSqrt :: Integer -> Integer
 integerSqrt n

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -24,6 +24,7 @@ import Panoptic.NId
   , fourLegSkeleton
   , mkNId
   , nSigma
+  , panopticAsset
   , panopticIsLong
   , panopticOptionRatio
   , panopticStrike
@@ -407,6 +408,8 @@ main = do
   mapM_
     (\leg -> do
       assertEqual ("isLong leg " ++ show leg) 1 (panopticIsLong skeleton leg)
+      -- TODO #28 item 0: asset bit (TokenId bit 64+48·leg) = 1 on every leg — single token1 basis
+      assertEqual ("asset leg " ++ show leg) 1 (panopticAsset skeleton leg)
       assertEqual ("width leg " ++ show leg) 1 (panopticWidth skeleton leg)
     )
     [0, 1, 2, 3]
@@ -934,6 +937,12 @@ main = do
   if abs (hi - am1) <= max 1 (am1 `div` 1000000) then pure ()
     else error ("fromChunk above range /= amount1: " ++ show hi ++ " vs " ++ show am1)
   putStrLn "ok: per-tick CLMM identity fromChunk = amount0 · unit fromCall"
+  -- TODO #28 item 0: strike of a chunk position is the integer sqrt of a·b (no Double).
+  let chS = unitChunk 40000 (mkTickSpacing 60)
+      SqrtPriceX96 aS = sqrtPriceX96 40000
+      SqrtPriceX96 bS = sqrtPriceX96 40060
+      StrikeX96 kS = CLMM.chunkStrike chS
+  assertEqual "chunkStrike = integerSqrt(a·b)" (integerSqrt (aS * bS)) kS
 
   -- TODO #25 (#36): four leg chunks 𝓛𝓒_leg from a MintPlan (≙ PanopticMath.getLiquidityChunk)
   -- and the 4-leg replica π̂^σ = Σ_leg [ H_leg(p) − π^φ(𝓛𝓒_leg; p) ].
@@ -954,10 +963,11 @@ main = do
         if abs (got - want) <= max 1 (want `div` 100000)
           then pure ()
           else error (lbl ++ ": want " ++ show want ++ " got " ++ show got)
-  relClose "put leg0 amount1 = or·ΔQ" (orOf 0 * 10 ^ (18 :: Int)) (chunkAmount1 (chunks !! 0))
-  relClose "put leg1 amount1 = or·ΔQ" (orOf 1 * 10 ^ (18 :: Int)) (chunkAmount1 (chunks !! 1))
-  relClose "call leg2 amount0 = or·ΔQ" (orOf 2 * 10 ^ (18 :: Int)) (chunkAmount0 (chunks !! 2))
-  relClose "call leg3 amount0 = or·ΔQ" (orOf 3 * 10 ^ (18 :: Int)) (chunkAmount0 (chunks !! 3))
+  -- TODO #28 item 0: asset = 1 on all legs (PanopticMath.getLiquidityChunk: asset==1 →
+  -- getLiquidityForAmount1), so or(leg)·ΔQ_υ is the token1 notional of EVERY leg.
+  sequence_
+    [ relClose ("leg " ++ show leg ++ " amount1 = or·ΔQ (asset=1)") (orOf leg * 10 ^ (18 :: Int)) (chunkAmount1 (chunks !! leg))
+    | leg <- [0 .. 3] ]
   assertEqual "legLiquidity = chunkLiquidity" (chunkLiquidity (chunks !! 3)) (legLiquidity planBig 3)
   -- Replica: zero at p* (all legs OTM), non-negative everywhere, and each leg's
   -- mint value H_leg dominates its principal.


### PR DESCRIPTION
## Summary
- Spec §4 Item 0 (2026-08-24 ladder replication): `asset` bit written (= 1 on all legs, single token1 basis) and `legLiquidity` switched to Panoptic polarity — fixes an on-chain sizing mismatch present since #57
- `strikeAndRatio` via `integerSqrt` (no Double on the strike); `SqrtGrid.mulDiv` + staged Uniswap forms in `chunkAmount0/1`, `legLiquidity`, `legMintValue`; uint128 checks
- `docs/BITWIDTHS.md` bit-width table for the Solidity twins

## Linked issue
Solves #61 (parent #59)

## Test plan
- [x] `stack build --ghc-options=-Werror` clean
- [x] `stack test`: asset = 1 ×4, all legs amount1 = or·ΔQ, chunkStrike = integerSqrt(a·b), identity + replica tests green
- [x] app regenerates plots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULfhs3u6dy5tjf5UaoS6GG