### PR TITLE
feat(todo-28.1): lnQ96 continuous integer log (Solady lnWad port); Hop B panel back

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -426,6 +426,17 @@ main = do
       (Cell (legsLayout legsCfg replicaPlan))
       (Cell (replicaLayout replicaCfg replicaPlan pStar0 []))
     )
+
+  -- TODO #28.1: with the continuous log (lnQ96) the Hop B Carr–Madan limit is
+  -- smooth on the ±60-tick window — the comparison #36 (c) was blocked on.
+  -- Units differ (token1 vs N_id-scaled return), so side by side, not overlaid;
+  -- the overlay with the scale bridge is Phase 1 (T1 vs T0).
+  writePanel
+    "outputs/Payoffs/Replica/panel-replica-vs-hopB.png"
+    (Beside
+      (Cell (replicaLayout replicaCfg replicaPlan pStar0 []))
+      (Cell (variancePortfolioLayout hopBNid hopBAtm (PayoffX96 0) (mkTargetVega 1) (sqrtPriceX96 (-60)) (sqrtPriceX96 60)))
+    )
   writePanel
     "outputs/Payoffs/variance-portfolio-vs-gammaCoordinate.png"
     (Cell

--- a/src/Payoffs/Log.hs
+++ b/src/Payoffs/Log.hs
@@ -1,24 +1,102 @@
 {-# LANGUAGE PatternSynonyms #-}
 
+-- | Log contract on the sqrt grid, with a CONTINUOUS integer log (TODO #28
+-- item 1).  `nakedLogQ96 p p*` = ln(p/p*) in Q96 = 2·ln(p½/p½*), computed as
+--
+--   x = mulDiv(p½, WAD, p½*)            (WAD-scaled sqrt-price ratio)
+--   l = lnWad x                          (Solady FixedPointMathLib.lnWad, WAD)
+--   nakedLogQ96 = floor(2·l·Q96 / WAD)   (signed: Haskell `div` floors)
+--
+-- `lnWad` is a line-by-line port of Solady's (8,8)-term rational
+-- approximation: `sar` ↦ arithmetic shift (`shiftR` on Integer floors),
+-- `sdiv` ↦ `quot` (truncates toward zero), all in unbounded Integer (the EVM
+-- twin is int256; every intermediate stays below 2^255 for x < 2^255).
+-- Error: Solady states "approximation, monotonically increasing" and gives no
+-- bound; the test suite MEASURES it (docs/BITWIDTHS.md).  The previous
+-- tick-quantized version is kept as `nakedLogTickQ96` for regression only:
+-- its error is ≤ ½·ln(1.0001) ≈ 5e-5 absolute in ln(p/p*).
 module Payoffs.Log
   ( nakedLogQ96
+  , nakedLogTickQ96
+  , lnWad
+  , lnQ96
+  , pattern WAD
   , payoff
   , logContract
   ) where
+
+import Data.Bits (shiftL, shiftR, xor, (.&.), (.|.))
 
 import qualified Payoffs.Payoff as Payoff
 import Payoffs.Forward (AtmForward, unAtmForward)
 import Panoptic.NId (NId, scaleByNId)
 import SqrtGrid
-  ( SqrtPriceX96
+  ( SqrtPriceX96(..)
   , PayoffX96(..)
+  , mulDiv
   , pattern Q96
   , tickBase
   , tickFromSqrtPriceX96
   )
 
+pattern WAD :: Integer
+pattern WAD = 1000000000000000000
+
+-- | Solady `lnWad`: ln(x) for x in WAD, result in WAD.  x must be > 0.
+lnWad :: Integer -> Integer
+lnWad x0
+  | x0 <= 0 = error "Payoffs.Log.lnWad: undefined for x <= 0"
+  | otherwise =
+      let
+        -- r = 255 ^ log2(x)  (branchless MSB search, as in the assembly)
+        lt a b = if a < b then 1 else 0 :: Integer
+        r1 = lt 0xffffffffffffffffffffffffffffffff x0 `shiftL` 7
+        r2 = r1 .|. (lt 0xffffffffffffffff (x0 `shiftR` fromInteger r1) `shiftL` 6)
+        r3 = r2 .|. (lt 0xffffffff (x0 `shiftR` fromInteger r2) `shiftL` 5)
+        r4 = r3 .|. (lt 0xffff (x0 `shiftR` fromInteger r3) `shiftL` 4)
+        r5 = r4 .|. (lt 0xff (x0 `shiftR` fromInteger r4) `shiftL` 3)
+        deBruijnIdx = (0x8421084210842108cc6318c6db6d54be `shiftR` fromInteger (x0 `shiftR` fromInteger r5)) .&. 0x1f
+        tbl = 0xf8f9f9faf9fdfafbf9fdfcfdfafbfcfef9fafdfafcfcfbfefafafcfbffffffff :: Integer
+        byteAt i w = (w `shiftR` (8 * (31 - fromInteger i))) .&. 0xff   -- EVM `byte(i, w)`
+        r  = r5 `xor` byteAt deBruijnIdx tbl
+        -- reduce x to (1, 2) * 2^96
+        x  = (x0 `shiftL` fromInteger r) `shiftR` 159
+        sar96 v = v `shiftR` 96
+        p0 = sar96 ((3273285459638523848632254066296 + x) * x)
+        p1 = sar96 ((24828157081833163892658089445524 + p0) * x)
+        p2 = sar96 ((43456485725739037958740375743393 + p1) * x) - 11111509109440967052023855526967
+        p3 = sar96 (p2 * x) - 45023709667254063763336534515857
+        p4 = sar96 (p3 * x) - 14706773417378608786704636184526
+        p5 = p4 * x - (795164235651350426258249787498 `shiftL` 96)
+        q0 = 5573035233440673466300451813936 + x
+        q1 = 71694874799317883764090561454958 + sar96 (x * q0)
+        q2 = 283447036172924575727196451306956 + sar96 (x * q1)
+        q3 = 401686690394027663651624208769553 + sar96 (x * q2)
+        q4 = 204048457590392012362485061816622 + sar96 (x * q3)
+        q5 = 31853899698501571402653359427138 + sar96 (x * q4)
+        q6 = 909429971244387300277376558375 + sar96 (x * q5)
+        pq = p5 `quot` q6                                            -- sdiv
+        s1 = 1677202110996718588342820967067443963516166 * pq
+        s2 = 16597577552685614221487285958193947469193820559219878177908093499208371 * (159 - r) + s1
+        s3 = 600920179829731861736702779321621459595472258049074101567377883020018308 + s2
+      in
+        s3 `shiftR` 174                                              -- sar(174, p)
+
+-- | ln(p/p*) = 2·ln(p½/p½*), Q96-scaled, floor.
+lnQ96 :: SqrtPriceX96 -> SqrtPriceX96 -> PayoffX96
+lnQ96 (SqrtPriceX96 p) (SqrtPriceX96 pStar)
+  | pStar <= 0 || p <= 0 = error "Payoffs.Log.lnQ96: sqrt prices must be > 0"
+  | otherwise =
+      let x = mulDiv p WAD pStar
+          l = lnWad x
+      in  PayoffX96 (mulDiv (2 * l) Q96 WAD)
+
 nakedLogQ96 :: SqrtPriceX96 -> AtmForward -> PayoffX96
-nakedLogQ96 spot atm =
+nakedLogQ96 spot atm = lnQ96 spot (unAtmForward atm)
+
+-- | Tick-quantized log (pre-#28.1), regression reference only.
+nakedLogTickQ96 :: SqrtPriceX96 -> AtmForward -> PayoffX96
+nakedLogTickQ96 spot atm =
   let
     i = tickFromSqrtPriceX96 spot
     iStar = tickFromSqrtPriceX96 (unAtmForward atm)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -42,7 +42,7 @@ import Payoffs.Forward
   , nakedForwardQ96
   )
 import qualified Payoffs.Forward as Fwd
-import Payoffs.Log (logContract, nakedLogQ96)
+import Payoffs.Log (lnQ96, lnWad, logContract, nakedLogQ96, nakedLogTickQ96, pattern WAD)
 import qualified Payoffs.Log as PLog
 import Payoffs.VariancePortfolio
   ( fromDef6
@@ -350,7 +350,11 @@ main = do
     expectedLog =
       floor (fromIntegral Q96 * fromIntegral (i10 - i0) * log tickBase)
     PayoffX96 log10 = nakedLogQ96 s10 atm0
-  assertEqual "naked log is (i-i*) ln λ in Q96" expectedLog log10
+  -- TODO #28.1: continuous log agrees with the tick formula AT a tick price
+  -- (both are 10·ln λ here); tolerance covers lnWad approx + Double floor.
+  if abs (log10 - expectedLog) <= Q96 `div` 1000000000
+    then putStrLn "ok: naked log ≈ (i-i*) ln λ at a tick price (1e-9 Q96)"
+    else error ("naked log vs tick formula: " ++ show log10 ++ " vs " ++ show expectedLog)
   let SqrtPriceX96 word10 = s10
   if log10 == word10
     then error "log must not be ln of the Q96 word"
@@ -361,6 +365,42 @@ main = do
     (let PayoffX96 y = PLog.payoff n32 s10 atm0 in y)
   _ <- evaluate (logContract n32 atm0)
   putStrLn "ok: logContract Payoff"
+
+  -- TODO #28.1: lnWad port + lnQ96 properties.
+  assertEqual "lnWad(WAD) = 0" 0 (lnWad WAD)
+  let e18 = 2718281828459045235 :: Integer  -- e·WAD (floor)
+  if abs (lnWad e18 - WAD) <= 10 then putStrLn "ok: lnWad(e) = WAD ± 10 wei"
+    else error ("lnWad(e) = " ++ show (lnWad e18))
+  if abs (lnWad (2 * WAD) - 693147180559945309) <= 10 then putStrLn "ok: lnWad(2) ± 10 wei"
+    else error ("lnWad(2) = " ++ show (lnWad (2 * WAD)))
+  if abs (lnWad (WAD `div` 2) + 693147180559945309) <= 10 then putStrLn "ok: lnWad(1/2) ± 10 wei"
+    else error ("lnWad(1/2) = " ++ show (lnWad (WAD `div` 2)))
+  -- monotone on a log-spaced grid
+  let grid = [ WAD * k `div` 100 | k <- [1 .. 99] ] ++ [ WAD * k | k <- [1 .. 1000] ]  -- strictly increasing, no duplicates
+  if and (zipWith (<) (map lnWad grid) (map lnWad (drop 1 grid)) ) then putStrLn "ok: lnWad monotone"
+    else error "lnWad not monotone"
+  -- lnQ96 vs tick log at every 10th tick on ±3000: measured max |diff| ≤ ½ ln λ · Q96 (tick error)
+  let halfTickErr = floor (0.5 * log tickBase * fromIntegral Q96 :: Double) + Q96 `div` 1000000 :: Integer
+      diffs = [ abs (a - b)
+              | i <- [-3000, -2990 .. 3000]
+              , let PayoffX96 a = nakedLogQ96 (sqrtPriceX96 i) atm0
+              , let PayoffX96 b = nakedLogTickQ96 (sqrtPriceX96 i) atm0 ]
+  if maximum diffs <= halfTickErr then putStrLn ("ok: lnQ96 vs tick log, max diff " ++ show (maximum diffs) ++ " ≤ ½ ln λ Q96")
+    else error ("lnQ96 vs tick log max diff " ++ show (maximum diffs) ++ " > " ++ show halfTickErr)
+  -- lnQ96 vs Double reference (plot boundary): measured max relative error, reported
+  let refErr = maximum
+        [ abs (fromIntegral a - 2 * log (fromIntegral p / fromIntegral Q96) * fromIntegral Q96) / fromIntegral Q96
+        | i <- [-3000, -2990 .. 3000], i /= 0
+        , let SqrtPriceX96 p = sqrtPriceX96 i
+        , let PayoffX96 a = lnQ96 (SqrtPriceX96 p) (sqrtPriceX96 0) ] :: Double
+  if refErr <= 1.0e-12 then putStrLn ("ok: lnQ96 vs Double ln, max abs err " ++ show refErr ++ " (Q96 units)")
+    else error ("lnQ96 vs Double ln err " ++ show refErr)
+  -- continuity: strictly increasing across a sub-tick step
+  let SqrtPriceX96 s0 = sqrtPriceX96 0
+      PayoffX96 lA = lnQ96 (SqrtPriceX96 (s0 + s0 `div` 100000)) (sqrtPriceX96 0)
+      PayoffX96 lB = lnQ96 (SqrtPriceX96 (s0 + s0 `div` 50000)) (sqrtPriceX96 0)
+  if 0 < lA && lA < lB then putStrLn "ok: lnQ96 continuous below one tick (no sawtooth)"
+    else error "lnQ96 not increasing within a tick"
 
   let
     remaining = PayoffX96 1000


### PR DESCRIPTION
## Summary
- `Payoffs.Log.lnWad` Integer port of Solady `lnWad`; `lnQ96` = ln(p/p*) in Q96; `nakedLogQ96` switched (tick version kept for regression)
- Measured: lnWad(1)=0, lnWad(e/2/½) ±10 wei, monotone, lnQ96 vs tick ≤ ½ ln λ·Q96, vs Double 5.6e-17, no sawtooth within a tick
- Re-adds `panel-replica-vs-hopB.png` (smooth now)

## Linked issue
Solves #63 (parent #59); closes #36 (c)

## Test plan
- [x] `stack build --ghc-options=-Werror` and `stack test --ghc-options=-Werror` clean
- [x] plots regenerated and inspected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULfhs3u6dy5tjf5UaoS6GG