### PR TITLE
feat(todo-28.2): T1 geometric ladder — regressions of Theorems 7/9/10 and Prop 1; T1-vs-T0 overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ Proof shape: rung edges geometric; primitive \(W(p,t)=\ln t + p^2/(2t^2)\); tele
 
 **Corollary 3 (residual numerical problem).** \(e^\sigma_W\) decomposes as truncation (in \(S\)) + tick discretization (Proposition 1) + binning/7-bit quantization (relative \(\le1/(2\,\mathrm{or}(\mathrm{leg}))\)). The optimizer reduces to a 1-D sweep in \(S\) (equivalently `VolRangeWidth`) with a quantization report; the remaining theory gap is norm C (reweighting by the pricing measure \(m\), #17–#18).
 
-**Implementation status.** T0 with continuous \(\ln\) (`lnQ96`, PR #64) and T2 (`LegChunk`, `VolatilityReplica`, PR #57; token1 basis PR #62) exist; T1, \(\mathcal B\), \(e^\sigma_W\) are TODO #28 items 2–3 (Haskell regressions of Theorems 3, 9, 10 and Corollary 1). Lean modules: `GeomProfile`, `GeomMixture`, `LadderPrincipal` (`develop` 8fdd875), `ClmmIdentity`, `LadderLimit` (`feat/lean4-spec` 36a560b, PR #46).
+**Implementation status.** T0 with continuous \(\ln\) (`lnQ96`, PR #64), T2 (`LegChunk`, `VolatilityReplica`, PR #57; token1 basis PR #62) and **T1** (`Payoffs.LadderPosition`: `ladderChunks`, `hedgedRung`, `ladderT1`, `ladderN1`, `cOfS`; regressions of Theorems 7(i), 9, 10 and Proposition 1 — T1/\(\mathcal N_1\) matches \(c(4000)\cdot\)logPortfolio to \(2.8\times10^{-6}\) at \(\Delta_i=10\); `outputs/Payoffs/Replica/panel-t1-vs-t0.png`) exist; \(\mathcal B\), \(e^\sigma_W\) are TODO #28 item 3. Lean modules: `GeomProfile`, `GeomMixture`, `LadderPrincipal` (`develop` 8fdd875), `ClmmIdentity`, `LadderLimit` (`feat/lean4-spec` 36a560b, PR #46).
 
 ## MODEL_CLOSURE
 

--- a/TODO.md
+++ b/TODO.md
@@ -171,7 +171,7 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
 28. **T1/T2 ladder replication of `VariancePortfolio` (Panoptic × LDF hybrid)** — `docs`→`fix`/`feat` — [#59](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/59)
    - Spec: `docs/superpowers/specs/2026-08-24-scratchpad-ladder-replication-design.md` (v3; Reality Checker + Solidity SC Engineer ×2)
    - T0 continuum → T1 geometric ladder \(\ell(\xi^\star,\iota;x)\) (fixed benchmark, Bunni-realizable) → T2 4-leg via \(\mathcal{B}\) on token1 notional (`asset = 1` all legs); knobs \(\theta_{\mathrm{LDF}}=(\xi_P,\xi_C,\omega)\); norm B, C later
-   - Sub-issues: **0 ✓** [#61](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/61)/PR #62 (asset = 1 all legs, integerSqrt strike, mulDiv staged forms, `docs/BITWIDTHS.md`); **1 ✓** [#63](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/63)/PR #64 (`lnQ96`); 2 Phase 1; 3 Phase 2; 4 README — next: 2
+   - Sub-issues: **0 ✓** [#61](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/61)/PR #62 (asset = 1 all legs, integerSqrt strike, mulDiv staged forms, `docs/BITWIDTHS.md`); **1 ✓** [#63](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/63)/PR #64 (`lnQ96`); **2 ✓** `Payoffs.LadderPosition` (T1; regressions of Thm 7(i)/9/10, Prop 1; T1/N_1 vs c(4000)·logPortfolio 2.8e-6); 3 Phase 2 (\(\mathcal B\), `replicaError`, width sweep); **4 ✓** README § REPLICATION_THEORY — next: 3
    - Supersedes TODO #25 (c) (Hop B comparison) via Item 1
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -55,6 +55,7 @@ import Payoffs.Forward (AtmForward(..))
 import Payoffs.Log (nakedLogQ96, nakedLogTickQ96)
 import Panoptic.NId (MintPlan(..), fourLegSkeleton, mkNId, volOrderToMintPlan)
 import Payoffs.VolatilityReplica (legsLayout, replicaLayout)
+import Payoffs.LadderPosition (cOfS, ladderDensityLayout, ladderFromSpan, ladderLayout, ladderReturnQ96, logPortfolioQ96)
 import Volatility.VolOrder (fixtureSymmetricVolOrder)
 import TargetVega (mkTargetVega, positionSizeForTargetVega)
 import Liquidity.LiquidityChunk
@@ -427,6 +428,33 @@ main = do
       (Cell (legsLayout legsCfg replicaPlan))
       (Cell (replicaLayout replicaCfg replicaPlan pStar0 []))
     )
+
+  -- TODO #28.2: T1 geometric ladder (S = 4000, Δ = 10, ι = 400, ξ*) — README § REPLICATION_THEORY
+  -- Theorem 10 overlay (same units: T1/N_1 vs c(S)·logPortfolio), residual, rung density.
+  let
+    ladT1  = ladderFromSpan (-2000) 2000 spacing10 0 (mkTargetVega (10 ^ (24 :: Int)))
+    cS     = cOfS 4000
+    t1Cfg  = SqrtPlot
+      { plotTitle  = "Thm 10: T1/N_1 (geometric ladder at ξ*, S=4000, Δ=10) vs c(S)·logPortfolio, c = " ++ take 7 (show cS)
+      , xAxisTitle = "sqrtPriceX96"
+      , yAxisTitle = "return (Q96)"
+      , xMin       = sqrtPriceX96 (-2000)
+      , xMax       = sqrtPriceX96 2000
+      }
+    resCfg = retitleSqrt t1Cfg "residual T1/N_1 − c(S)·logPortfolio (Q96)" "Q96"
+    resid p = let PayoffX96 a = ladderReturnQ96 ladT1 p
+                  PayoffX96 b = logPortfolioQ96 p (sqrtPriceX96 0)
+              in  PayoffX96 (a - floor (cS * fromIntegral b))
+    denCfg = retitleSqrt t1Cfg "rung liquidity L(i_x) = ΔQ·ℓ(ξ*, ι; x) (Thm 7)" "liquidity"
+  writePanel
+    "outputs/Payoffs/Replica/panel-t1-vs-t0.png"
+    (Beside
+      (Cell (ladderLayout t1Cfg ladT1))
+      (Cell (sqrtFunctionLayout resCfg PayoffY [("residual", resid)]))
+    )
+  writePanel
+    "outputs/Payoffs/Replica/t1-ladder-density.png"
+    (Cell (ladderDensityLayout denCfg ladT1))
 
   -- TODO #28.1 evidence: tick-quantized log (pre-#64, staircase) vs continuous
   -- lnQ96 on ±30 ticks, and their difference (bounded by ½ ln λ · Q96).

--- a/cfmm-scratchpad.cabal
+++ b/cfmm-scratchpad.cabal
@@ -42,6 +42,7 @@ library
       Payoffs.CLMMPosition
       Payoffs.CoveredCall
       Payoffs.Forward
+      Payoffs.LadderPosition
       Payoffs.Linear
       Payoffs.Log
       Payoffs.Payoff

--- a/src/Payoffs/LadderPosition.hs
+++ b/src/Payoffs/LadderPosition.hs
@@ -1,0 +1,188 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+-- | T1 — the geometric liquidity ladder (README § REPLICATION_THEORY, Defs 4/6/7;
+-- Lean lean4-spec LadderLimit / GeomMixture; TODO #28 item 2).
+--
+-- Rungs i_x = i_L + x·Δ_i, x ∈ [0, ι); L(i_x) = mulDiv(ΔQ_υ*, ℓ(ξ*, ι; x), Q96);
+-- hedged rung h_x(p) = H_x(p) − π^{ΔQ_X}(Id_{i_x}; p) with H_x = amount1 below i*,
+-- p²·amount0 above (Lean `LadderLimit.hedgedRung`); T1(p) = Σ_x (L(i_x)/L_unit)·h_x(p)
+-- (`ladderT1`); N_1 = Σ_x (L(i_x)/L_unit)·H_x(p*) (`ladderN1`).
+-- Theorem 10 (`ladder_tendsto_logPortfolio_explicit`): T1/N_1 → c(S)·logPortfolio with
+--   c(S) = 1 / (2·(ln λ·S/4 + (1 − λ^{−S/2})/2)),  S = span in ticks, strike at midpoint.
+module Payoffs.LadderPosition
+  ( Ladder(..)
+  , ladderFromSpan
+  , ladderChunks
+  , hedgedRung
+  , mintValue
+  , ladderT1
+  , ladderN1
+  , ladderReturnQ96
+  , logPortfolioQ96
+  , cOfS
+  , ladderLayout
+  , ladderDensityLayout
+  ) where
+
+import Graphics.Rendering.Chart.Easy (Layout)
+
+import Liquidity.LiquidityChunk
+  ( LiquidityChunk
+  , chunkAmount0
+  , chunkAmount1
+  , chunkLiquidity
+  , chunkTickLower
+  , chunkTickUpper
+  , createChunk
+  , unitLiquidity
+  )
+import Liquidity.LiquidityGrid
+  ( LadderResolution
+  , LiquidityDensityX96(..)
+  , XiX96
+  , ell
+  , mkLadderResolution
+  , unLadderResolution
+  , xiStar
+  )
+import qualified Payoffs.CLMMPosition as CLMM
+import Payoffs.Forward (AtmForward(..), nakedForwardQ96)
+import Payoffs.Log (lnQ96)
+import qualified Payoffs.Payoff as Payoff
+import Plotting.PlotSqrt (PlotY(..), sqrtFunctionLayout)
+import SqrtGrid
+  ( PayoffX96(..)
+  , SqrtPlot
+  , SqrtPriceX96(..)
+  , Tick
+  , TickSpacing
+  , mulDiv
+  , pattern Q96
+  , sqrtPriceX96
+  , unTickSpacing
+  )
+import TargetVega (TargetVega, unTargetVega)
+
+-- | A ladder: span, spacing, mint tick, target vega, profile ratio.
+data Ladder = Ladder
+  { ladderLo      :: Tick          -- i_L
+  , ladderHi      :: Tick          -- i_U
+  , ladderSpacing :: TickSpacing   -- Δ_i
+  , ladderStar    :: Tick          -- i*
+  , ladderVega    :: TargetVega    -- ΔQ_υ*
+  , ladderXi      :: XiX96         -- ξ (default ξ*)
+  }
+
+-- | Ladder over [i_L, i_U] at ξ*; i_L, i_U, i* must be multiples of Δ_i and i_L < i* < i_U.
+ladderFromSpan :: Tick -> Tick -> TickSpacing -> Tick -> TargetVega -> Ladder
+ladderFromSpan lo hi sp star vega
+  | lo >= hi || not (lo < star && star < hi) =
+      error "Payoffs.LadderPosition.ladderFromSpan: need i_L < i* < i_U"
+  | any (\t -> t `mod` d /= 0) [lo, hi, star] =
+      error "Payoffs.LadderPosition.ladderFromSpan: i_L, i*, i_U must be multiples of Δ_i"
+  | otherwise = Ladder lo hi sp star vega (xiStar sp)
+  where d = unTickSpacing sp
+
+iota :: Ladder -> LadderResolution
+iota l = mkLadderResolution ((ladderHi l - ladderLo l) `div` unTickSpacing (ladderSpacing l))
+
+rungTick :: Ladder -> Int -> Tick
+rungTick l x = ladderLo l + x * unTickSpacing (ladderSpacing l)
+
+-- | L(i_x) = mulDiv(ΔQ_υ*, ℓ(ξ, ι; x), Q96) as unit-spacing chunks; zero-liquidity rungs
+-- are an error (Bunni: invalid params), never dropped.
+ladderChunks :: Ladder -> [LiquidityChunk]
+ladderChunks l =
+  [ if liq <= 0 then error ("Payoffs.LadderPosition.ladderChunks: zero liquidity at rung " ++ show x)
+               else createChunk i (i + d) liq
+  | x <- [0 .. n - 1]
+  , let i = rungTick l x
+  , let LiquidityDensityX96 w = ell (ladderXi l) (iota l) x
+  , let liq = mulDiv (unTargetVega (ladderVega l)) w Q96
+  ]
+  where
+    n = unLadderResolution (iota l)
+    d = unTickSpacing (ladderSpacing l)
+
+-- | H_x(p): what the long rung holds after mint, in token1 at p (unit-liquidity chunk).
+mintValue :: Tick -> LiquidityChunk -> SqrtPriceX96 -> PayoffX96
+mintValue star ch (SqrtPriceX96 p)
+  | chunkTickLower ch < star = chunkAmount1 ch
+  | otherwise =
+      let PayoffX96 am0 = chunkAmount0 ch
+      in  PayoffX96 (mulDiv (mulDiv p p Q96) am0 Q96)
+
+-- | h_x(p) = H_x(p) − π^{ΔQ_X}(Id; p) on a UNIT-liquidity chunk at the rung's ticks.
+hedgedRung :: Tick -> LiquidityChunk -> SqrtPriceX96 -> PayoffX96
+hedgedRung star ch p =
+  let unitCh = createChunk (chunkTickLower ch) (chunkTickUpper ch) unitLiquidity
+      PayoffX96 h = mintValue star unitCh p
+      PayoffX96 principal = Payoff.runPayoff (CLMM.toPayoff (CLMM.fromChunk unitCh)) p
+  in  PayoffX96 (h - principal)
+
+-- | T1(p) = Σ_x (L(i_x)/L_unit) · h_x(p)   (Lean `ladderT1`), token1.
+ladderT1 :: Ladder -> Payoff.Payoff SqrtPriceX96
+ladderT1 l =
+  Payoff.Payoff $ \p ->
+    PayoffX96 $ sum
+      [ mulDiv (chunkLiquidity ch) h unitLiquidity
+      | ch <- ladderChunks l
+      , let PayoffX96 h = hedgedRung (ladderStar l) ch p
+      ]
+
+-- | N_1 = Σ_x (L(i_x)/L_unit) · H_x(p*)   (Lean `ladderN1`), token1 mint notional.
+ladderN1 :: Ladder -> PayoffX96
+ladderN1 l =
+  let pStar = sqrtPriceX96 (ladderStar l)
+  in  PayoffX96 $ sum
+        [ mulDiv (chunkLiquidity ch) h unitLiquidity
+        | ch <- ladderChunks l
+        , let unitCh = createChunk (chunkTickLower ch) (chunkTickLower ch + unTickSpacing (ladderSpacing l)) unitLiquidity
+        , let PayoffX96 h = mintValue (ladderStar l) unitCh pStar
+        ]
+
+-- | T1(p)/N_1 in Q96 (dimensionless return).
+ladderReturnQ96 :: Ladder -> SqrtPriceX96 -> PayoffX96
+ladderReturnQ96 l p =
+  let PayoffX96 t1 = Payoff.runPayoff (ladderT1 l) p
+      PayoffX96 n1 = ladderN1 l
+  in  PayoffX96 (mulDiv t1 Q96 n1)
+
+-- | logPortfolio(P, P*) = (P − P*)/P* − ln(P/P*) in Q96 (T0 bare; continuous lnQ96).
+logPortfolioQ96 :: SqrtPriceX96 -> SqrtPriceX96 -> PayoffX96
+logPortfolioQ96 p pStar =
+  let PayoffX96 f = nakedForwardQ96 p (AtmForward pStar)
+      PayoffX96 l = lnQ96 p pStar
+  in  PayoffX96 (f - l)
+
+-- | Theorem 10's constant c(S) = 1 / (2·(ln λ · S/4 + (1 − λ^{−S/2})/2)), Double (test/plot boundary).
+cOfS :: Int -> Double
+cOfS s =
+  let lnLam = log 1.0001
+      sD = fromIntegral s
+  in  1 / (2 * (lnLam * sD / 4 + (1 - 1.0001 ** (negate sD / 2)) / 2))
+
+-- | T1/N_1 vs c(S)·logPortfolio on one sqrt axis (Theorem 10 overlay).
+ladderLayout :: SqrtPlot -> Ladder -> Layout Double Double
+ladderLayout config l =
+  let s = ladderHi l - ladderLo l
+      c = cOfS s
+      pStar = sqrtPriceX96 (ladderStar l)
+      scaledT0 p = let PayoffX96 y = logPortfolioQ96 p pStar in PayoffX96 (floor (c * fromIntegral y))
+  in  sqrtFunctionLayout config PayoffY
+        [ ("T1/N_1 (ladder, ξ*)", ladderReturnQ96 l)
+        , ("c(S)·logPortfolio (T0)", scaledT0)
+        ]
+
+-- | Rung liquidities L(i_x) as a step function of sqrt price.
+ladderDensityLayout :: SqrtPlot -> Ladder -> Layout Double Double
+ladderDensityLayout config l =
+  let chs = ladderChunks l
+      d = unTickSpacing (ladderSpacing l)
+      at (SqrtPriceX96 p) =
+        PayoffX96 $ sum [ chunkLiquidity ch
+                        | ch <- chs
+                        , let SqrtPriceX96 a = sqrtPriceX96 (chunkTickLower ch)
+                        , let SqrtPriceX96 b = sqrtPriceX96 (chunkTickLower ch + d)
+                        , a <= p && p < b ]
+  in  sqrtFunctionLayout config PayoffY [ ("L(i_x) = ΔQ·ℓ(ξ*,ι;x)", at) ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -213,6 +213,8 @@ import qualified Payoffs.CLMMPosition as CLMM
 import Payoffs.CLMMPosition (clmmChunk)
 import Panoptic.LegChunk (legChunk, legChunks, legLiquidity)
 import Payoffs.VolatilityReplica (fourLegReplica, legMintValue)
+import Payoffs.LadderPosition
+  ( cOfS, hedgedRung, ladderChunks, ladderFromSpan, ladderN1, ladderReturnQ96, ladderT1, logPortfolioQ96 )
 import Data.Vector ((!))
 import qualified Data.Vector as V
 import TickPath (TickPath(..), mkTickPath, pathLength, ticks)
@@ -995,6 +997,63 @@ main = do
     , let rhs = am1 + mulDiv (mulDiv pRaw pRaw Q96) am0 Q96
     ]
   putStrLn "ok: principal_inRange (Lean P2) = amount1(a,p) + p²·amount0(p,b)"
+
+  -- ===== TODO #28.2 — T1 ladder: regressions of README § REPLICATION_THEORY =====
+  let
+    vegaL  = mkTargetVega (10 ^ (24 :: Int))
+    spL    = mkTickSpacing 10
+    lad    = ladderFromSpan (-2000) 2000 spL 0 vegaL           -- S = 4000, ι = 400, strike at midpoint
+    chunksL = ladderChunks lad
+    pStarL = sqrtPriceX96 0
+    PayoffX96 n1 = ladderN1 lad
+  assertEqual "ladder has ι = S/Δ rungs" 400 (length chunksL)
+  -- Theorem 7(i): ℓ(ξ*, ι; x) equals the normalized sampled K^{-1/2} profile (Q96, 1e-9 rel)
+  let
+    iotaL = mkLadderResolution 400
+    samples = [ (Q96 * Q96) `div` raw | x <- [0 .. 399], let SqrtPriceX96 raw = sqrtPriceX96 (-2000 + 10 * x) ]
+    total = sum samples
+    worst = maximum [ abs (fromIntegral (unLiquidityDensityX96 (ell (xiStar spL) iotaL x)) - fromIntegral (samples !! x) * fromIntegral Q96 / fromIntegral total) / fromIntegral Q96
+                    | x <- [0 .. 399] ] :: Double
+  if worst <= 1.0e-9 then putStrLn ("ok: Thm 7(i) ℓ(ξ*) = normalized K^{-1/2} samples, max err " ++ show worst)
+    else error ("Thm 7(i) fails: " ++ show worst)
+  -- Theorem 9: h_x(p*) = 0 on every rung; h_x ≥ 0 on a grid (X96 floors: 1e6 wei ≈ 1e-12 of the unit chunk)
+  let tolW = 1000000 :: Integer
+  sequence_
+    [ if abs h0 <= tolW && all (>= negate tolW) hs then pure ()
+        else error ("Thm 9 fails at rung " ++ show (chunkTickLower ch) ++ ": h(p*)=" ++ show h0 ++ " min h=" ++ show (minimum hs))
+    | ch <- chunksL
+    , let PayoffX96 h0 = hedgedRung 0 ch pStarL
+    , let hs = [ y | i <- [-3000, -2500 .. 3000], let PayoffX96 y = hedgedRung 0 ch (sqrtPriceX96 i) ]
+    ]
+  putStrLn "ok: Thm 9 hedged rung = 0 at p*, ≥ 0 (400 rungs × 13 prices)"
+  -- Theorem 10: T1/N_1 ≈ c(S)·logPortfolio, S = 4000 → c = 2.62294; exclusion band |i| < 2Δ
+  let
+    cS = cOfS 4000
+    relErrs = [ abs (fromIntegral t1r - cS * fromIntegral lp) / (cS * fromIntegral lp)
+              | i <- [-1800, -1500 .. 1800], abs i >= 20
+              , let p = sqrtPriceX96 i
+              , let PayoffX96 t1r = ladderReturnQ96 lad p
+              , let PayoffX96 lp  = logPortfolioQ96 p pStarL ] :: [Double]
+  if abs (cS - 2.62294) < 2.0e-5 then putStrLn ("ok: c(4000) = " ++ show cS ++ " (Lean 2.62294)")
+    else error ("c(4000) = " ++ show cS)
+  if maximum relErrs <= 5.0e-3 then putStrLn ("ok: Thm 10 T1/N_1 vs c(S)·logPortfolio, max rel err " ++ show (maximum relErrs) ++ " at Δ=10")
+    else error ("Thm 10 fails: max rel err " ++ show (maximum relErrs))
+  -- Proposition 1: residual shrinks ~O(Δ²): Δ = 200 → 20 should cut the spread by ≥ 20× (100× nominal)
+  let
+    spreadAt d =
+      let ld = ladderFromSpan (-2000) 2000 (mkTickSpacing d) 0 vegaL
+          rs = [ fromIntegral t1r / fromIntegral lp
+               | i <- [-1800, -1500 .. 1800], abs i >= 2 * d
+               , let p = sqrtPriceX96 i
+               , let PayoffX96 t1r = ladderReturnQ96 ld p
+               , let PayoffX96 lp  = logPortfolioQ96 p pStarL ] :: [Double]
+      in  (maximum rs - minimum rs) / cS
+    s200 = spreadAt 200
+    s20  = spreadAt 20
+  if s200 / s20 >= 20 then putStrLn ("ok: Prop 1 spread ratio Δ200/Δ20 = " ++ show (s200 / s20) ++ " (≥ 20; O(Δ²) nominal 100)")
+    else error ("Prop 1 fails: spreads " ++ show (s200, s20))
+  _ <- evaluate (Payoff.runPayoff (ladderT1 lad) pStarL)
+  if n1 > 0 then putStrLn "ok: N_1 > 0" else error "N_1 <= 0"
   -- TODO #28 item 0: strike of a chunk position is the integer sqrt of a·b (no Double).
   let chS = unitChunk 40000 (mkTickSpacing 60)
       SqrtPriceX96 aS = sqrtPriceX96 40000


### PR DESCRIPTION
## Summary
- `Payoffs.LadderPosition`: T1 as Definition 7 (rungs from `ell`/`xiStar`, hedged rung mirroring Lean `LadderLimit.hedgedRung`, `ladderT1`/`ladderN1`), `logPortfolioQ96` (T0 bare), `cOfS` (Theorem 10 constant)
- Regressions instead of search: Thm 7(i) 2e-18, Thm 9 (400 rungs), c(4000) = 2.6229435 vs Lean 2.62294, Thm 10 T1/N_1 vs c·logPortfolio **2.8e-6** at Δ=10, Prop 1 spread ratio 50 (Δ 200→20)
- Plots: `panel-t1-vs-t0.png` (first legitimate overlay — same units by Thm 10 — plus residual), `t1-ladder-density.png`
- Dropped from the spec's Item 2: ξ-sweep harness and noise-floor table (Theorem 7)

## Linked issue
Solves #73 (parent #59)

## Test plan
- [x] `stack build --ghc-options=-Werror` and `stack test --ghc-options=-Werror` green
- [x] plots regenerated and inspected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULfhs3u6dy5tjf5UaoS6GG