### PR TITLE
refactor(todo-29): single T0 definition; VariancePortfolio labelled reference-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ L\,(b-a) & p_{1/2} \ge b
 \(h_x(p_{1/2}) = H_x(p_{1/2}) - \pi^{\Delta Q_X}(\mathrm{Id}_{i_x};p_{1/2})\).
 
 **Definition 7 (tiers).**
-- T0: \(\Pi^\sigma_{\mathrm{opt}}(P) = N_{\mathrm{id}}\big[(P-P^\star)/P^\star - \ln(P/P^\star)\big] + R\), \(\;\mathrm{logPortfolio}(P,P^\star) = (P-P^\star)/P^\star - \ln(P/P^\star)\).
+- T0 (**reference only**, not a position): \(\Pi^\sigma_{\mathrm{opt}}(P) = N_{\mathrm{id}}\big[(P-P^\star)/P^\star - \ln(P/P^\star)\big] + R\), \(\;\mathrm{logPortfolio}(P,P^\star) = (P-P^\star)/P^\star - \ln(P/P^\star)\) — single code definition `Payoffs.Log.logPortfolioQ96`; `VariancePortfolio` is \(N_{\mathrm{id}}\cdot\) it \(+R\) (TODO #29).
 - T1: \(L(i_x) = \Delta Q_v^\star\,\ell(\xi^\star,\iota;x)\), \(\;\hat\pi^\sigma_{\mathrm{T1}}(p) = \sum_x \tfrac{L(i_x)}{L_{\mathrm{unit}}}\,h_x(p)\), \(\;\mathcal N_1 = \sum_x \tfrac{L(i_x)}{L_{\mathrm{unit}}}H_x(p^\star)\).
 - T2: \(\hat\pi^\sigma(p) = \sum_{\mathrm{leg}=0}^{3}\big[H_{\mathrm{leg}}(p) - \pi^{\Delta Q_X}(\mathcal{LC}_{\mathrm{leg}};p)\big]\), \(\mathcal{LC}_{\mathrm{leg}}\) from \(\mathrm{or}(\mathrm{leg})\cdot\texttt{positionSize}\) on the token1 basis (`asset = 1`).
 

--- a/TODO.md
+++ b/TODO.md
@@ -174,6 +174,9 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - Sub-issues: **0 ✓** [#61](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/61)/PR #62 (asset = 1 all legs, integerSqrt strike, mulDiv staged forms, `docs/BITWIDTHS.md`); **1 ✓** [#63](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/63)/PR #64 (`lnQ96`); **2 ✓** `Payoffs.LadderPosition` (T1; regressions of Thm 7(i)/9/10, Prop 1; T1/N_1 vs c(4000)·logPortfolio 2.8e-6); **3 ✓** `Panoptic.Binning` + `replicaError` (Cor 1/Thm 8 regressions; \(e^\sigma_W(\mathcal B)=2.1\)e-4 at S=4000, \(\approx S^2\) sweep; or = (127,…) = equal notional per leg, Cor 4); **4 ✓** README § REPLICATION_THEORY — **#28 complete** except the peer follow-ons (O(Δi) bound, off-midpoint strike, χ via Thm 5)
    - Supersedes TODO #25 (c) (Hop B comparison) via Item 1
 
+29. **Single T0 definition; `VariancePortfolio` = reference only** — `refactor` — [#77](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/77)
+   - `logPortfolioQ96` moves to `Payoffs.Log`; `VariancePortfolio.fromDef6` = \(N_{\mathrm{id}}\cdot\)`logPortfolioQ96` + R, `fromLegs` delegates; module labelled T0 reference; `panel-replica-vs-hopB` retired (superseded by t1-vs-t0 / t2-vs-t1)
+
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 
 ### Package / tree moves (README `//` notes; not done)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -522,16 +522,6 @@ main = do
       (Cell (sqrtFunctionLayout logDiffCfg PayoffY [("tick − continuous", logDiff)]))
     )
 
-  -- TODO #28.1: with the continuous log (lnQ96) the Hop B Carr–Madan limit is
-  -- smooth on the ±60-tick window — the comparison #36 (c) was blocked on.
-  -- Units differ (token1 vs N_id-scaled return), so side by side, not overlaid;
-  -- the overlay with the scale bridge is Phase 1 (T1 vs T0).
-  writePanel
-    "outputs/Payoffs/Replica/panel-replica-vs-hopB.png"
-    (Beside
-      (Cell (replicaLayout replicaCfg replicaPlan pStar0 []))
-      (Cell (variancePortfolioLayout hopBNid hopBAtm (PayoffX96 0) (mkTargetVega 1) (sqrtPriceX96 (-60)) (sqrtPriceX96 60)))
-    )
   writePanel
     "outputs/Payoffs/variance-portfolio-vs-gammaCoordinate.png"
     (Cell

--- a/src/Payoffs/LadderPosition.hs
+++ b/src/Payoffs/LadderPosition.hs
@@ -46,8 +46,7 @@ import Liquidity.LiquidityGrid
   , xiStar
   )
 import qualified Payoffs.CLMMPosition as CLMM
-import Payoffs.Forward (AtmForward(..), nakedForwardQ96)
-import Payoffs.Log (lnQ96)
+import Payoffs.Log (logPortfolioQ96)
 import qualified Payoffs.Payoff as Payoff
 import Plotting.PlotSqrt (PlotY(..), sqrtFunctionLayout)
 import SqrtGrid
@@ -147,13 +146,6 @@ ladderReturnQ96 l p =
   let PayoffX96 t1 = Payoff.runPayoff (ladderT1 l) p
       PayoffX96 n1 = ladderN1 l
   in  PayoffX96 (mulDiv t1 Q96 n1)
-
--- | logPortfolio(P, P*) = (P − P*)/P* − ln(P/P*) in Q96 (T0 bare; continuous lnQ96).
-logPortfolioQ96 :: SqrtPriceX96 -> SqrtPriceX96 -> PayoffX96
-logPortfolioQ96 p pStar =
-  let PayoffX96 f = nakedForwardQ96 p (AtmForward pStar)
-      PayoffX96 l = lnQ96 p pStar
-  in  PayoffX96 (f - l)
 
 -- | Theorem 10's constant c(S) = 1 / (2·(ln λ · S/4 + (1 − λ^{−S/2})/2)), Double (test/plot boundary).
 cOfS :: Int -> Double

--- a/src/Payoffs/Log.hs
+++ b/src/Payoffs/Log.hs
@@ -20,6 +20,7 @@ module Payoffs.Log
   , nakedLogTickQ96
   , lnWad
   , lnQ96
+  , logPortfolioQ96
   , pattern WAD
   , payoff
   , logContract
@@ -28,7 +29,7 @@ module Payoffs.Log
 import Data.Bits (shiftL, shiftR, xor, (.&.), (.|.))
 
 import qualified Payoffs.Payoff as Payoff
-import Payoffs.Forward (AtmForward, unAtmForward)
+import Payoffs.Forward (AtmForward(..), nakedForwardQ96, unAtmForward)
 import Panoptic.NId (NId, scaleByNId)
 import SqrtGrid
   ( SqrtPriceX96(..)
@@ -116,3 +117,13 @@ payoff nId spot atm =
 logContract :: NId -> AtmForward -> Payoff.Payoff SqrtPriceX96
 logContract nId atm =
   Payoff.Payoff (\spot -> payoff nId spot atm)
+
+-- | T0 bare: logPortfolio(P, P*) = (P − P*)/P* − ln(P/P*) in Q96, continuous log.
+-- The single definition of the Carr–Madan / Demeterfi log portfolio in this
+-- codebase (README § REPLICATION_THEORY Def 7; Lean VolInstrument.logPortfolio).
+-- VariancePortfolio (T0 with N_id scale and R) is built from this.
+logPortfolioQ96 :: SqrtPriceX96 -> SqrtPriceX96 -> PayoffX96
+logPortfolioQ96 p pStar =
+  let PayoffX96 f = nakedForwardQ96 p (AtmForward pStar)
+      PayoffX96 l = lnQ96 p pStar
+  in  PayoffX96 (f - l)

--- a/src/Payoffs/VariancePortfolio.hs
+++ b/src/Payoffs/VariancePortfolio.hs
@@ -1,3 +1,10 @@
+-- | T0 — the continuum variance portfolio (Hop A/B), REFERENCE / DIAGNOSTIC ONLY.
+-- Π^σ_opt(P) = N_id·[(P − P*)/P* − ln(P/P*)] + R, built from the single T0
+-- definition `Payoffs.Log.logPortfolioQ96` (continuous lnQ96).  It is NOT a
+-- position: a strike continuum is not EVM-realizable.  The realizable
+-- benchmark is T1 (`Payoffs.LadderPosition`, Theorem 10: T1/N_1 → c(S)·this),
+-- and the replica error `VolatilityReplica.replicaError` is T2 vs T1.
+-- README § REPLICATION_THEORY Def 7; TODO #29.
 module Payoffs.VariancePortfolio
   ( VariancePortfolio
   , fromLegs
@@ -24,11 +31,9 @@ import Pricing.PriceDeformation (EtaX96)
 import qualified Payoffs.Payoff as Payoff
 import Payoffs.Forward
   ( AtmForward
-  , forward
-  , nakedForwardQ96
   , unAtmForward
   )
-import Payoffs.Log (logContract, nakedLogQ96)
+import Payoffs.Log (logPortfolioQ96)
 import Panoptic.NId (MintPlan, NId, scaleByNId)
 import TargetVega (TargetVega, targetVegaFromMint, unTargetVega)
 import SqrtGrid
@@ -44,35 +49,25 @@ import Volatility.VolatilityGrid (gammaCoordinate)
 
 newtype VariancePortfolio = VariancePortfolio (Payoff.Payoff SqrtPriceX96)
 
-constantPayoff :: PayoffX96 -> Payoff.Payoff SqrtPriceX96
-constantPayoff y = Payoff.Payoff (\_ -> y)
-
-fromLegs :: NId -> AtmForward -> PayoffX96 -> VariancePortfolio
-fromLegs nId atm remaining =
-  let
-    legs =
-      Payoff.addPayoff
-        (Payoff.subPayoff (forward nId atm) (logContract nId atm))
-        (constantPayoff remaining)
-    witness = unAtmForward atm
-    y = Payoff.runPayoff legs witness
-  in
-    assert (y == remaining) (VariancePortfolio legs)
-
+-- | Single T0 definition: N_id · logPortfolioQ96 + R  (asserted = R at P*).
 fromDef6 :: NId -> AtmForward -> PayoffX96 -> VariancePortfolio
 fromDef6 nId atm remaining =
   let
     pf = Payoff.Payoff $ \spot ->
       let
-        PayoffX96 f = nakedForwardQ96 spot atm
-        PayoffX96 l = nakedLogQ96 spot atm
+        PayoffX96 lp = logPortfolioQ96 spot (unAtmForward atm)
         PayoffX96 r = remaining
       in
-        PayoffX96 (scaleByNId nId (f - l) + r)
+        PayoffX96 (scaleByNId nId lp + r)
     witness = unAtmForward atm
     y = Payoff.runPayoff pf witness
   in
     assert (y == remaining) (VariancePortfolio pf)
+
+-- | Historical "legs" constructor (forward − log contract): now the same
+-- definition (TODO #29 — one T0, no second code path).
+fromLegs :: NId -> AtmForward -> PayoffX96 -> VariancePortfolio
+fromLegs = fromDef6
 
 toPayoff :: VariancePortfolio -> Payoff.Payoff SqrtPriceX96
 toPayoff (VariancePortfolio p) = p

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -42,8 +42,9 @@ import Payoffs.Forward
   , nakedForwardQ96
   )
 import qualified Payoffs.Forward as Fwd
-import Payoffs.Log (lnQ96, lnWad, logContract, nakedLogQ96, nakedLogTickQ96, pattern WAD)
+import Payoffs.Log (lnQ96, lnWad, logContract, logPortfolioQ96, nakedLogQ96, nakedLogTickQ96, pattern WAD)
 import qualified Payoffs.Log as PLog
+import qualified Payoffs.VariancePortfolio as VPort
 import Payoffs.VariancePortfolio
   ( fromDef6
   , fromLegs
@@ -215,7 +216,7 @@ import Panoptic.LegChunk (legChunk, legChunks, legLiquidity)
 import Payoffs.VolatilityReplica (ErrorX96(..), fourLegReplica, legMintValue, replicaError, windowTicks)
 import Panoptic.Binning (binNotionals, binToLegs, ladderFromVolOrder, mintPlanFromLadder, quantizationReport, QuantizationRow(..))
 import Payoffs.LadderPosition
-  ( cOfS, hedgedRung, ladderChunks, ladderFromSpan, ladderN1, ladderReturnQ96, ladderT1, logPortfolioQ96 )
+  ( cOfS, hedgedRung, ladderChunks, ladderFromSpan, ladderN1, ladderReturnQ96, ladderT1 )
 import Data.Vector ((!))
 import qualified Data.Vector as V
 import TickPath (TickPath(..), mkTickPath, pathLength, ticks)
@@ -420,6 +421,14 @@ main = do
     yLegs10 = Payoff.runPayoff (toPayoff piLegs) s10
     yDef10 = Payoff.runPayoff (toPayoff piDef6) s10
   assertEqual "fromLegs = fromDef6 off ATM" yLegs10 yDef10
+  -- TODO #29: single T0 definition — fromLegs = N_id·logPortfolioQ96 + R, exactly, at several ticks
+  sequence_
+    [ assertEqual ("T0 single definition at tick " ++ show i) (scaleByNId n32 lp + rRaw) y
+    | i <- [-3000, -700, -10, 10, 700, 3000]
+    , let p = sqrtPriceX96 i
+    , let PayoffX96 lp = logPortfolioQ96 p (Fwd.unAtmForward atm0)
+    , let PayoffX96 rRaw = remaining
+    , let PayoffX96 y = Payoff.runPayoff (VPort.toPayoff (fromLegs n32 atm0 remaining)) p ]
 
   assertThrows "mkTargetVega 0 rejected" (mkTargetVega 0)
   assertThrows "mkTargetVega (-1) rejected" (mkTargetVega (-1))


### PR DESCRIPTION
## Summary
- One T0: `Payoffs.Log.logPortfolioQ96`; `VariancePortfolio.fromDef6 = N_id·logPortfolioQ96 + R`, `fromLegs` delegates — the duplicate code path is gone
- `VariancePortfolio` module header and README Def 7 now say what it is: T0 reference/diagnostic, not a position; the benchmark is T1
- `panel-replica-vs-hopB.png` retired (superseded by `panel-t1-vs-t0` / `panel-t2-vs-t1`); `variance-portfolio*.png` kept
- Regression: `fromLegs = N_id·logPortfolioQ96 + R` exactly at 6 ticks; all #28 regressions unchanged

## Linked issue
Solves #77

## Test plan
- [x] `stack build/test --ghc-options=-Werror` green; app regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULfhs3u6dy5tjf5UaoS6GG