### PR TITLE
feat(todo-30): path accrual — fees/LVR per chunk on a tagged path; channel statics panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,14 @@ Proof shape: rung edges geometric; primitive \(W(p,t)=\ln t + p^2/(2t^2)\); tele
 
 **Implementation status.** T0 with continuous \(\ln\) (`lnQ96`, PR #64), T2 (`LegChunk`, `VolatilityReplica`, PR #57; token1 basis PR #62) and **T1** (`Payoffs.LadderPosition`: `ladderChunks`, `hedgedRung`, `ladderT1`, `ladderN1`, `cOfS`; regressions of Theorems 7(i), 9, 10 and Proposition 1 — T1/\(\mathcal N_1\) matches \(c(4000)\cdot\)logPortfolio to \(2.8\times10^{-6}\) at \(\Delta_i=10\); `outputs/Payoffs/Replica/panel-t1-vs-t0.png`) exist; \(\mathcal B\) (`Panoptic.Binning`: `ladderFromVolOrder`, `binToLegs`, `mintPlanFromLadder`, `quantizationReport`) and \(e^\sigma_W\) (`VolatilityReplica.replicaError`, `windowTicks`) exist — the optimizer is now a `VolRangeWidth` sweep (`outputs/Payoffs/Replica/panel-t2-vs-t1.png`, sweep printed by the app). Lean modules: `GeomProfile`, `GeomMixture`, `LadderPrincipal` (`develop` 8fdd875), `ClmmIdentity`, `LadderLimit` (`feat/lean4-spec` 36a560b, PR #46).
 
+## CHANNEL_STATICS
+
+Comparative statics of the two legs of \(\pi^{\varphi}=\pi^{\phi}-\pi^{\mathrm{LVR}}\) on the \(\mathcal B\) plan (S=4000), from `Payoffs.PathAccrual` over a synthetic tagged path (TODO #30; the prover path replaces it in #34). Per step inside a chunk: amounts moved by `getAmount0/1`, fee on the token paid in, LVR on arb steps \(=\) the concavity gap (Theorem 5). \(\mathrm{LVR}_{\mathrm{net}}=\mathrm{LVR}_{\mathrm{gross}}-\mathrm{fees}_{\mathrm{arb}}\) (after-fee convention); \(\pi^{\varphi}=\mathrm{fees}_{\mathrm{trans}}-\mathrm{LVR}_{\mathrm{net}}\).
+
+**Fact 1 (share axis, `panel-accrual-vs-arbshare.png`).** At fixed step size, \(\mathrm{fees}_{\mathrm{trans}}\) is antitone and \(\mathrm{LVR}_{\mathrm{gross}}\) monotone in \([\nu_{\mathrm{arb}}/\nu]\), both linear; total fees are invariant to the tag. Below the fee band \(\mathrm{LVR}_{\mathrm{net}}<0\) for every share: arbs pay more fee than they extract, and the seller's \(\pi^{\varphi}\) falls in the share only through lost transactional fees.
+
+**Fact 2 (vol axis, `panel-accrual-vs-vol.png`).** At share ½, \(\mathrm{LVR}_{\mathrm{net}}\) crosses zero where the step exceeds the fee band (≈40–50 ticks for \(\phi_X=5\,\)bp, \(\phi_M=30\,\)bp), and \(\pi^{\varphi}\) peaks there: too little vol → few fees, too much → LVR dominates. This is the band-crossing form of \(\lambda_{X/M}\) (MODEL_CLOSURE §2) seen directly, and the reason \(\inf_\tau\) has an interior solution: the tax moves \([\nu_{\mathrm{arb}}/\nu]\) (Fact 1) but the *sign* of the arb's extraction is set by vol vs fee (Fact 2).
+
 ## MODEL_CLOSURE
 
 Exact functional forms for \(\pi^{\phi}(\pi^{\Delta Q}_{\mathrm{trans}}(r^{e}_{\mathrm{trans}}))\) and \(\pi^{\mathrm{LVR}}(\pi^{\Delta Q}_{\mathrm{arb}}(r^{e}_{\mathrm{arb}}))\). Both channels have the same shape — a token-side mixture weighted by \(r^{e}\) — which is what closes the model.

--- a/TODO.md
+++ b/TODO.md
@@ -177,6 +177,10 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
 29. **Single T0 definition; `VariancePortfolio` = reference only** — `refactor` — [#77](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/77)
    - `logPortfolioQ96` moves to `Payoffs.Log`; `VariancePortfolio.fromDef6` = \(N_{\mathrm{id}}\cdot\)`logPortfolioQ96` + R, `fromLegs` delegates; module labelled T0 reference; `panel-replica-vs-hopB` retired (superseded by t1-vs-t0 / t2-vs-t1)
 
+30. **Path accrual — fees and LVR per chunk along a tagged tick path; comparative statics** — `feat` — [#79](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/79)
+   - `Payoffs.PathAccrual`: per-step amounts moved (Uniswap), fee on the token paid in, LVR on arb steps = concavity gap (Thm 5); split fees_trans/fees_arb/LVR_gross; LVR_net = LVR_gross − fees_arb; \(\pi^{\varphi}\) = fees_trans − LVR_net
+   - Synthetic tagged path (LCG + Bresenham share); 4-leg roll-up; panels vs \([\nu_{\mathrm{arb}}/\nu]\) and vs step size; prover path replaces it in #34
+
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 
 ### Package / tree moves (README `//` notes; not done)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -60,6 +60,7 @@ import Payoffs.LadderPosition (ladderN1, ladderT1)
 import Volatility.VolOrder (VolOrder, mkVolOrder, mkVolRangeWidth, mkVolSkew)
 import Payoffs.VolatilityReplica (fourLegReplica)
 import Panoptic.NId (volOrderToTokenId)
+import qualified Payoffs.PathAccrual as PA
 import Payoffs.LadderPosition (cOfS, ladderDensityLayout, ladderFromSpan, ladderLayout, ladderReturnQ96, logPortfolioQ96)
 import Volatility.VolOrder (fixtureSymmetricVolOrder)
 import TargetVega (mkTargetVega, positionSizeForTargetVega)
@@ -500,6 +501,43 @@ main = do
   mapM_ (\(s, e) -> putStrLn ("  S=" ++ show s ++ "  e=" ++ show (fromIntegral e / fromIntegral Q96 :: Double))) sweep
   putStrLn "quantization report S=4000 (leg, or, relErr ppm, bound ppm):"
   mapM_ print (quantizationReport lad4k vo4k)
+
+  -- TODO #30: path accrual comparative statics on the 𝓑 plan (S=4000):
+  -- (a) vs atomic arb share at fixed step size; (b) vs step size (vol proxy) at share 50%.
+  let
+    phiXa = mkFeePips 500
+    phiMa = mkFeePips 3000
+    toD :: Integer -> Double
+    toD x = fromIntegral x / 1.0e18   -- token1 units (ΔQ_υ = 1e24 liquidity on the 𝓑 plan)
+    totalA accs = foldr PA.addAccrual PA.zeroAccrual accs
+    rowFor :: Int -> Int -> (Integer, Integer, Integer, Integer, Integer)
+    rowFor step sharePct =
+      let path = PA.syntheticPath 11 0 step 400 (PA.mkArbShareWad (toInteger sharePct * PA.WAD_SHARE `div` 100))
+          acc  = totalA (PA.planAccrual phiXa phiMa plan4k path)
+          (PayoffX96 lvrN, PayoffX96 net) = PA.netAccrual acc
+      in  (PA.feesTrans acc, PA.feesArb acc, PA.lvrGross acc, lvrN, net)
+    sharesA = [0, 10 .. 100] :: [Int]
+    bySh = [ (fromIntegral s / 100, rowFor 20 s) | s <- sharesA ]
+    stepsA = [5, 10, 20, 40, 60, 80, 120, 160, 240] :: [Int]
+    bySt = [ (fromIntegral st, rowFor st 50) | st <- stepsA ]
+    pick f xs = [ (x, toD (f r)) | (x, r) <- xs ]
+    s1 (a,_,_,_,_) = a; s2 (_,b,_,_,_) = b; s3 (_,_,c,_,_) = c; s4 (_,_,_,d,_) = d; s5 (_,_,_,_,e) = e
+  writePanel
+    "outputs/Payoffs/Accrual/panel-accrual-vs-arbshare.png"
+    (Beside
+      (Cell (PA.linesLayout "4-leg accrual vs [ν_arb/ν] (step 20 ticks, 400 steps, φ_X=5bp φ_M=30bp)" "[ν_arb/ν]" "token1"
+        [("fees_trans", pick s1 bySh), ("fees_arb", pick s2 bySh), ("LVR_gross", pick s3 bySh)]))
+      (Cell (PA.linesLayout "net: LVR_net = LVR_gross − fees_arb;  π^φ = fees_trans − LVR_net" "[ν_arb/ν]" "token1"
+        [("LVR_net", pick s4 bySh), ("π^φ (seller net)", pick s5 bySh)]))
+    )
+  writePanel
+    "outputs/Payoffs/Accrual/panel-accrual-vs-vol.png"
+    (Beside
+      (Cell (PA.linesLayout "4-leg accrual vs step size (vol proxy), share 50%" "step (ticks)" "token1"
+        [("fees_trans", pick s1 bySt), ("fees_arb", pick s2 bySt), ("LVR_gross", pick s3 bySt)]))
+      (Cell (PA.linesLayout "LVR_net crosses zero where the step exceeds the fee band" "step (ticks)" "token1"
+        [("LVR_net", pick s4 bySt), ("π^φ (seller net)", pick s5 bySt)]))
+    )
 
   -- TODO #28.1 evidence: tick-quantized log (pre-#64, staircase) vs continuous
   -- lnQ96 on ±30 ticks, and their difference (bounded by ½ ln λ · Q96).

--- a/cfmm-scratchpad.cabal
+++ b/cfmm-scratchpad.cabal
@@ -46,6 +46,7 @@ library
       Payoffs.LadderPosition
       Payoffs.Linear
       Payoffs.Log
+      Payoffs.PathAccrual
       Payoffs.Payoff
       Payoffs.RangeAccrualNote
       Payoffs.Return

--- a/src/Payoffs/PathAccrual.hs
+++ b/src/Payoffs/PathAccrual.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+-- | Path accrual — the two legs of π^φ = π^φ_fee − π^LVR per chunk along a
+-- tagged tick path (TODO #30; README § MODEL_CLOSURE, REPLICATION_THEORY Thm 5).
+--
+-- Per step p_i → p_j inside a chunk (overlap of [p_i,p_j] with [a,b]):
+--   amount0 moved = L·(1/lo − 1/hi),  amount1 moved = L·(hi − lo)     (Uniswap)
+--   price UP   (trader pays token1, receives token0): fee = φ_M·amount1
+--   price DOWN (trader pays token0, receives token1): fee = φ_X·amount0·p_j²
+--   LVR (arb steps only) = arb's profit marked at the corrected price p_j:
+--     up:   amount0·p_j² − amount1     down: amount1 − amount0·p_j²        (≥ 0: concavity)
+-- Fees are split by tag; LVR_net = LVR_gross − fees_arb (README after-fee
+-- convention); π^φ (seller's net accrual) = fees_trans − LVR_net.
+-- All token1-valued, Q96 fixed point, mulDiv chains (docs/BITWIDTHS.md).
+module Payoffs.PathAccrual
+  ( Tag(..)
+  , Step(..)
+  , Accrual(..)
+  , zeroAccrual
+  , addAccrual
+  , ArbShareWad
+  , mkArbShareWad
+  , unArbShareWad
+  , pattern WAD_SHARE
+  , syntheticPath
+  , stepAccrual
+  , pathAccrual
+  , planAccrual
+  , netAccrual
+  , linesLayout
+  ) where
+
+import Data.Colour
+import Data.Colour.Names
+import Graphics.Rendering.Chart.Easy
+
+import Liquidity.LiquidityChunk
+  ( LiquidityChunk
+  , chunkLiquidity
+  , chunkTickLower
+  , chunkTickUpper
+  )
+import Panoptic.LegChunk (legChunks)
+import Panoptic.MintPlan (MintPlan)
+import Pricing.Stremia (FeePips, unFeePips)
+import SqrtGrid (PayoffX96(..), SqrtPriceX96(..), Tick, mulDiv, pattern Q96, sqrtPriceX96)
+
+data Tag = Trans | Arb
+  deriving (Show, Eq)
+
+-- | One price move on the path with its flow tag.
+data Step = Step
+  { stepFrom :: Tick
+  , stepTo   :: Tick
+  , stepTag  :: Tag
+  }
+  deriving (Show, Eq)
+
+data Accrual = Accrual
+  { feesTrans :: Integer   -- token1, Q96-scaled payoff units
+  , feesArb   :: Integer
+  , lvrGross  :: Integer
+  }
+  deriving (Show, Eq)
+
+zeroAccrual :: Accrual
+zeroAccrual = Accrual 0 0 0
+
+addAccrual :: Accrual -> Accrual -> Accrual
+addAccrual (Accrual a b c) (Accrual a' b' c') = Accrual (a + a') (b + b') (c + c')
+
+-- | Atomic arb share [ν_arb/ν] as a WAD (1e18 = 1) — read, never computed.
+newtype ArbShareWad = ArbShareWad Integer
+  deriving (Show, Eq, Ord)
+
+pattern WAD_SHARE :: Integer
+pattern WAD_SHARE = 1000000000000000000
+
+mkArbShareWad :: Integer -> ArbShareWad
+mkArbShareWad s
+  | s < 0 || s > WAD_SHARE = error "Payoffs.PathAccrual.mkArbShareWad: share must be in [0, WAD]"
+  | otherwise = ArbShareWad s
+
+unArbShareWad :: ArbShareWad -> Integer
+unArbShareWad (ArbShareWad s) = s
+
+-- | Deterministic synthetic path: n steps of ±stepTicks from i0; direction from a
+-- 32-bit LCG (seed); tag = Arb on the Bresenham schedule of the share
+-- (⌊(k+1)·s⌋ > ⌊k·s⌋), so #Arb/n → s exactly.  A vol proxy is stepTicks.
+syntheticPath :: Int -> Tick -> Int -> Int -> ArbShareWad -> [Step]
+syntheticPath seed i0 stepTicks n (ArbShareWad s) =
+  go 0 i0 (fromIntegral seed :: Integer)
+  where
+    go k i st
+      | k >= n = []
+      | otherwise =
+          let st' = (1664525 * st + 1013904223) `mod` 4294967296
+              up = (st' `div` 65536) `mod` 2 == 0
+              j = if up then i + stepTicks else i - stepTicks
+              kI = toInteger k
+              isArb = ((kI + 1) * s) `div` WAD_SHARE > (kI * s) `div` WAD_SHARE
+          in  Step i j (if isArb then Arb else Trans) : go (k + 1) j st'
+
+-- | Accrual of one step on one chunk (token1, Q96 units as PayoffX96).
+stepAccrual :: FeePips -> FeePips -> LiquidityChunk -> Step -> Accrual
+stepAccrual phiX phiM ch (Step iFrom iTo tag)
+  | iFrom == iTo = zeroAccrual
+  | hi <= lo     = zeroAccrual                        -- no overlap with the range
+  | otherwise =
+      let l = chunkLiquidity ch
+          amt0 = mulDiv (l * Q96) (hi - lo) hi `div` lo  -- L(1/lo − 1/hi) staged (getAmount0)
+          amt1 = mulDiv l (hi - lo) Q96                  -- L(hi − lo)            (getAmount1)
+          SqrtPriceX96 pj = sqrtPriceX96 iTo
+          amt0AtPj = mulDiv (mulDiv pj pj Q96) amt0 Q96  -- amount0 valued in token1 at p_j
+          fee = if goingUp
+                  then mulDiv amt1 (unFeePips phiM) 1000000
+                  else mulDiv amt0AtPj (unFeePips phiX) 1000000
+          lvr = if goingUp then amt0AtPj - amt1 else amt1 - amt0AtPj
+      in  case tag of
+            Trans -> Accrual fee 0 0
+            Arb   -> Accrual 0 fee (max 0 lvr)
+  where
+    goingUp = iTo > iFrom
+    SqrtPriceX96 a = sqrtPriceX96 (chunkTickLower ch)
+    SqrtPriceX96 b = sqrtPriceX96 (chunkTickUpper ch)
+    SqrtPriceX96 pFrom = sqrtPriceX96 iFrom
+    SqrtPriceX96 pTo = sqrtPriceX96 iTo
+    lo = max a (min pFrom pTo)
+    hi = min b (max pFrom pTo)
+
+pathAccrual :: FeePips -> FeePips -> LiquidityChunk -> [Step] -> Accrual
+pathAccrual phiX phiM ch = foldr (addAccrual . stepAccrual phiX phiM ch) zeroAccrual
+
+-- | Four-leg roll-up over a MintPlan (each leg chunk accrues on its own range).
+planAccrual :: FeePips -> FeePips -> MintPlan -> [Step] -> [Accrual]
+planAccrual phiX phiM plan path = [ pathAccrual phiX phiM ch path | ch <- legChunks plan ]
+
+-- | (LVR_net, π^φ): LVR after the fees arbs paid; seller's net accrual = fees_trans − LVR_net.
+netAccrual :: Accrual -> (PayoffX96, PayoffX96)
+netAccrual (Accrual ft fa lg) =
+  let lvrNet = lg - fa
+  in  (PayoffX96 lvrNet, PayoffX96 (ft - lvrNet))
+
+-- | Generic named-lines layout on Double axes (comparative statics).
+linesLayout :: String -> String -> String -> [(String, [(Double, Double)])] -> Layout Double Double
+linesLayout title xTitle yTitle series = execEC $ do
+  layout_title .= title
+  layout_x_axis . laxis_title .= xTitle
+  layout_y_axis . laxis_title .= yTitle
+  setColors (map opaque [blue, red, darkgreen, orange, purple, black])
+  mapM_ (\(name, pts) -> plot (line name [pts])) series

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -215,6 +215,7 @@ import Payoffs.CLMMPosition (clmmChunk)
 import Panoptic.LegChunk (legChunk, legChunks, legLiquidity)
 import Payoffs.VolatilityReplica (ErrorX96(..), fourLegReplica, legMintValue, replicaError, windowTicks)
 import Panoptic.Binning (binNotionals, binToLegs, ladderFromVolOrder, mintPlanFromLadder, quantizationReport, QuantizationRow(..))
+import qualified Payoffs.PathAccrual as PA
 import Payoffs.LadderPosition
   ( cOfS, hedgedRung, ladderChunks, ladderFromSpan, ladderN1, ladderReturnQ96, ladderT1 )
 import Data.Vector ((!))
@@ -1104,6 +1105,49 @@ main = do
   let rows = quantizationReport ladW voWide
   sequence_ [ if qRelErrPpm r <= qBoundPpm r + 1 then pure () else error ("quantization bound fails: " ++ show r) | r <- rows ]
   putStrLn ("ok: quantization report " ++ show [ (qOr r, qRelErrPpm r, qBoundPpm r) | r <- rows ])
+
+  -- ===== TODO #30 — path accrual: fees and LVR per chunk along a tagged path =====
+  let
+    phiXp = mkFeePips 500      -- 5 bp on token0 (down moves)
+    phiMp = mkFeePips 3000     -- 30 bp on token1 (up moves)
+    chA   = createChunk (-500) 500 (10 ^ (24 :: Int))
+    shareOf s = PA.mkArbShareWad (s * PA.WAD_SHARE `div` 100)
+    pathAt s = PA.syntheticPath 7 0 20 400 (shareOf s)
+    accAt s = PA.pathAccrual phiXp phiMp chA (pathAt s)
+    nArb s = length [ () | PA.Step _ _ PA.Arb <- pathAt s ]
+  assertEqual "share 0 → no arb steps" 0 (nArb 0)
+  assertEqual "share 100 → all arb steps" 400 (nArb 100)
+  assertEqual "share 25 → 100 arb steps (Bresenham)" 100 (nArb 25)
+  -- LVR ≥ 0 on every arb step (concavity, Thm 5); zero at share 0
+  sequence_ [ if PA.lvrGross (PA.stepAccrual phiXp phiMp chA st) >= 0 then pure () else error ("negative LVR on " ++ show st) | st <- pathAt 100 ]
+  assertEqual "LVR = 0 at share 0" 0 (PA.lvrGross (accAt 0))
+  if PA.lvrGross (accAt 100) > 0 then putStrLn "ok: LVR > 0 at share 100" else error "no LVR at share 100"
+  -- total fees independent of tagging (same path, same fees; only the split moves)
+  let totalFees s = PA.feesTrans (accAt s) + PA.feesArb (accAt s)
+  assertEqual "total fees independent of tagging" (totalFees 0) (totalFees 100)
+  assertEqual "total fees independent of tagging (50)" (totalFees 0) (totalFees 50)
+  -- monotone in the share: LVR ↑, fees_trans ↓
+  let shares = [0, 25, 50, 75, 100]
+      lvrs = [ PA.lvrGross (accAt s) | s <- shares ]
+      fts  = [ PA.feesTrans (accAt s) | s <- shares ]
+  if and (zipWith (<=) lvrs (drop 1 lvrs)) && and (zipWith (>=) fts (drop 1 fts))
+    then putStrLn ("ok: LVR monotone ↑, fees_trans ↓ in arb share: " ++ show (zip shares lvrs))
+    else error ("monotonicity fails: " ++ show (lvrs, fts))
+  -- a single up-step: fee = φ_M·amount1, LVR = amount0·p_j² − amount1 > 0
+  let PA.Accrual _ fa1 lg1 = PA.stepAccrual phiXp phiMp chA (PA.Step 0 20 PA.Arb)
+      SqrtPriceX96 a0 = sqrtPriceX96 0
+      SqrtPriceX96 a20 = sqrtPriceX96 20
+      amt1 = mulDiv (10 ^ (24 :: Int)) (a20 - a0) Q96
+  assertEqual "up-step fee = φ_M·amount1" (mulDiv amt1 3000 1000000) fa1
+  if lg1 > 0 && lg1 < amt1 `div` 100 then putStrLn ("ok: up-step LVR small positive: " ++ show lg1 ++ " vs amount1 " ++ show amt1)
+    else error ("up-step LVR " ++ show lg1)
+  -- four-leg roll-up and net accrual sign: seller net = fees_trans − LVR_net
+  let accs = PA.planAccrual phiXp phiMp planB (PA.syntheticPath 11 0 20 400 (shareOf 50))
+      (PayoffX96 lvrN, PayoffX96 netS) = PA.netAccrual (foldr addAccrualT zeroT accs)
+      addAccrualT (PA.Accrual x y z) (PA.Accrual x' y' z') = PA.Accrual (x + x') (y + y') (z + z')
+      zeroT = PA.Accrual 0 0 0
+  assertEqual "plan accrual has 4 legs" 4 (length accs)
+  putStrLn ("ok: 4-leg net accrual at share 50: LVR_net = " ++ show lvrN ++ ", π^φ = " ++ show netS)
   -- TODO #28 item 0: strike of a chunk position is the integer sqrt of a·b (no Double).
   let chS = unitChunk 40000 (mkTickSpacing 60)
       SqrtPriceX96 aS = sqrtPriceX96 40000


### PR DESCRIPTION
## Summary
- `Payoffs.PathAccrual`: per-step fee (token paid in) and LVR (arb steps, concavity gap = Theorem 5) per chunk; 4-leg roll-up; after-fee LVR_net; seller's π^φ; synthetic tagged path with an atomic arb share
- Panels: accrual vs [ν_arb/ν] (Fact 1) and vs step size (Fact 2: LVR_net zero crossing at the fee band, π^φ peak) — first pictures of the channel half
- README § CHANNEL_STATICS records both facts and why they give an interior τ

## Linked issue
Solves #79

## Test plan
- [x] `stack build/test --ghc-options=-Werror` green (Bresenham counts, LVR ≥ 0, tag-invariant fees, monotonicity, up-step fee identity)
- [x] panels regenerated and inspected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULfhs3u6dy5tjf5UaoS6GG