### PR TITLE
feat(todo-33): ReplicaDelta — Δ̂^σ = ∂_P π̂^σ as a Greeks.Delta instance on the 4-leg replica

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -185,6 +185,7 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
 32. **Delta-hedge rebate: holder-hedged replication supersedes the signed transfer \(s\) (Defs 12–14, Prop B); #34 re-scoped into trans / holder-hedge / residual-arb** — `docs` — [#84](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/84) / [#85](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/85) — `docs/superpowers/specs/2026-08-25-scratchpad-delta-hedge-rebate-design.md`
    - Note: `docs/superpowers/specs/2026-08-25-scratchpad-price-update-transfer-design.md` — Prop A (roles), Defs 9–11 (signed \(s\), budget, equilibrium \(\mathrm{LVR}_{\mathrm{net}}=s^\star\nu_{\mathrm{arb}}\)), two-source path (GAMS round trips + external update rule)
    - #34 becomes: trans half = GAMS replay (given \([\nu_{\mathrm{trans}}/\nu]\), \(u\)); arb half = \(P_{\mathrm{ext}}\) + rule at \(s\) (\([\nu_{\mathrm{arb}}/\nu]\) as output). Implementation item next.
+33. **ReplicaDelta — \(\hat\Delta^\sigma=\partial_P\hat\pi^\sigma\) as a `Greeks.Delta` instance on the 4-leg replica (Def 12; rebate-note test §5.1)** — `feat` — [#86](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/86)
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -54,6 +54,7 @@ import Payoffs.CLMMPosition (chunkFromStrike, rhsPayoffLayout, scaledVsUnitLayou
 import Payoffs.Forward (AtmForward(..))
 import Payoffs.Log (nakedLogQ96, nakedLogTickQ96)
 import Panoptic.NId (MintPlan(..), fourLegSkeleton, mkNId, volOrderToMintPlan)
+import Payoffs.ReplicaDelta (replicaDeltaLayout)
 import Payoffs.VolatilityReplica (ErrorX96(..), legsLayout, replicaError, replicaLayout, windowTicks)
 import Panoptic.Binning (binToLegs, ladderFromVolOrder, mintPlanFromLadder, quantizationReport)
 import Payoffs.LadderPosition (ladderN1, ladderT1)
@@ -435,6 +436,12 @@ main = do
       (Cell (legsLayout legsCfg replicaPlan))
       (Cell (replicaLayout replicaCfg replicaPlan pStar0 []))
     )
+
+  -- TODO #33 (#86): Δ̂^σ = ∂_P π̂^σ — closed form vs central difference (rebate note Def 12).
+  let deltaCfg = retitleSqrt replicaCfg "Δ̂^σ = ∂_P π̂^σ (raw token0): closed form vs central difference" "token0 (raw)"
+  writePanel
+    "outputs/Payoffs/Replica/panel-replica-delta.png"
+    (Cell (replicaDeltaLayout deltaCfg replicaPlan pStar0))
 
   -- TODO #28.2: T1 geometric ladder (S = 4000, Δ = 10, ι = 400, ξ*) — README § REPLICATION_THEORY
   -- Theorem 10 overlay (same units: T1/N_1 vs c(S)·logPortfolio), residual, rung density.

--- a/cfmm-scratchpad.cabal
+++ b/cfmm-scratchpad.cabal
@@ -49,6 +49,7 @@ library
       Payoffs.PathAccrual
       Payoffs.Payoff
       Payoffs.RangeAccrualNote
+      Payoffs.ReplicaDelta
       Payoffs.Return
       Payoffs.Savings
       Payoffs.Swap

--- a/docs/BITWIDTHS.md
+++ b/docs/BITWIDTHS.md
@@ -20,6 +20,8 @@ Operand ranges: sqrt prices `a, b, p` ≤ 2^160 (Q64.96); liquidity `L` ≤ 2^12
 | rung liquidity `L(i_x)` | `mulDiv ΔQ ℓ Q96` | `positionSize`-style scaling | `ΔQ·ℓ` ≤ 2^224 | fits 256 |
 | binning `n_leg` | `Σ mulDiv L_x c_x Q96`, `c_x = b_x − a_x` | off-chain / view | ≤ 2^288 per term | `positionSize = n_max / 127` must be < 2^128 → require `n_max < 2^135` |
 | `ErrorX96` | `mulDiv d Q96 N_1`, square, sum, `integerSqrt` | **off-chain only** | unbounded on-chain | no EVM bound claimed |
+| `principalDelta` (∂_P principal = token0 held) | `mulDiv (L·Q96) (b − p̄) b `div` p̄`, p̄ = clamp(p; a, b) | `getAmount0ForLiquidity` at (p̄, b) | `L·Q96` ≤ 2^224 | fits 256; result < 2^128 |
+| `deltaOfPayoff` (generic ∂_P) | `mulDiv (ΔV) Q96 (ΔP)` | **off-chain / tests only** | `ΔV·Q96` ≤ 2^224 | signed; twin is the closed form, not the difference |
 | `lnQ96` (Item 1) | port of Solady `lnWad` on `mulDiv p WAD p*`, then `mulDiv (2·ln) Q96 WAD` | `FixedPointMathLib.lnWad` | int256 | signed: floor (Haskell `div`) vs truncate (Solidity `/`) — floor chosen |
 
 Rounding direction: `chunkAmount0/1` round **down**; Panoptic rounds long-closing amounts **up** (`getAmountsMoved`).

--- a/src/Greeks/Delta.hs
+++ b/src/Greeks/Delta.hs
@@ -3,6 +3,10 @@
 module Greeks.Delta
   ( Delta(..)
   , DeltaX96(..)
+  , PriceDeltaX96(..)
+  , PayoffDelta(..)
+  , deltaOfPayoff
+  , payoffDeltaLayout
   , pattern DELTA_ATM
   , coveredCallDelta
   , rangeAccrualDelta
@@ -18,8 +22,10 @@ import Graphics.Rendering.Chart.Easy
 import qualified Payoffs.Payoff as Payoff
 
 import OptionRatio (OptionRatio(..))
+import Plotting.PlotSqrt (PlotY(..), sqrtFunctionLayout)
 import SqrtGrid
   ( integerSqrt
+  , mulDiv
   , SqrtPriceX96(..)
   , PayoffX96(..)
   , SqrtPlot(..)
@@ -34,6 +40,39 @@ newtype Delta = Delta { runDelta :: SqrtPriceX96 -> Rational }
 -- Target δ ∈ [0, 1] in Q96 (Kristensen 3.23).
 newtype DeltaX96 = DeltaX96 Integer
   deriving (Show, Eq, Ord)
+
+-- | ∂_P V of a token1-valued payoff V with respect to PRICE P = p²/Q96:
+-- ΔV · Q96 / ΔP, i.e. a raw token0 amount (signed).  This is the delta that
+-- the hedge ledger of the rebate note (Defs 12–14) tracks in token units.
+newtype PriceDeltaX96 = PriceDeltaX96 Integer
+  deriving (Show, Eq, Ord)
+
+-- | A delta is a function of a payoff: `PayoffDelta` is the ∂_P of SOME
+-- `Payoff SqrtPriceX96`.  `deltaOfPayoff` is the generic (finite-difference)
+-- instance; `Payoffs.ReplicaDelta.replicaDelta` is the closed-form instance
+-- for `fourLegReplica`, tested against the generic one.
+newtype PayoffDelta = PayoffDelta { runPayoffDelta :: SqrtPriceX96 -> PriceDeltaX96 }
+
+-- | Central difference in price, bump = p/2^16 in sqrt-price (≈ 0.3 bp in P,
+-- ≈ 0.3 tick — narrower than any leg), floored at 1 wei.  Integer throughout; exact for payoffs that
+-- are linear in P on the bump window, O(bump) at kinks.
+deltaOfPayoff :: Payoff.Payoff SqrtPriceX96 -> PayoffDelta
+deltaOfPayoff (Payoff.Payoff f) =
+  PayoffDelta $ \(SqrtPriceX96 p) ->
+    let h = max 1 (p `div` 65536)
+        PayoffX96 vUp = f (SqrtPriceX96 (p + h))
+        PayoffX96 vDn = f (SqrtPriceX96 (p - h))
+        PayoffX96 pUp = Payoff.squareSqrtPrice (SqrtPriceX96 (p + h))
+        PayoffX96 pDn = Payoff.squareSqrtPrice (SqrtPriceX96 (p - h))
+    in  PriceDeltaX96 (mulDiv (vUp - vDn) Q96 (pUp - pDn))
+
+-- | Deltas on one sqrt axis; y = raw token0 (EVM word), plotted through the
+-- PayoffX96 channel of `sqrtFunctionLayout`.
+payoffDeltaLayout :: SqrtPlot -> [(String, PayoffDelta)] -> Layout Double Double
+payoffDeltaLayout config labeled =
+  sqrtFunctionLayout config (RawY "token0 (raw, signed)")
+    [ (lbl, \p -> let PriceDeltaX96 d = runPayoffDelta pd p in PayoffX96 d)
+    | (lbl, pd) <- labeled ]
 
 -- δ = 1/2
 pattern DELTA_ATM :: DeltaX96

--- a/src/Payoffs/ReplicaDelta.hs
+++ b/src/Payoffs/ReplicaDelta.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+-- | Δ̂^σ = ∂_P π̂^σ — the replica delta (rebate note Def 12), the closed-form
+-- `Greeks.Delta.PayoffDelta` instance for `Payoffs.VolatilityReplica.fourLegReplica`.
+--
+-- Per leg, with 𝓛𝓒 = (a, b, L) in sqrt-price and P = p²:
+--   ∂_P π^{ΔQ_X}(𝓛𝓒; P) = amount0(L, max(a, min(p, b)), b)   — the token0 the chunk
+--                          holds at p (amount0(𝓛𝓒) below range, 0 above, continuous);
+--   ∂_P H_leg            = 0 (put: H = amount1, constant) | amount0(𝓛𝓒) (call: H = P·amount0).
+-- So Δ̂^σ = Σ_leg [∂_P H_leg − ∂_P π^{ΔQ_X}]: 0 at p* (all legs OTM), ≤ 0 below p*,
+-- ≥ 0 above, nondecreasing (π̂^σ is convex).  Integer, `mulDiv` forms; raw token0.
+-- Lean twin: `principal_price_deriv` (peer item, next to `principal_price_second_deriv`).
+module Payoffs.ReplicaDelta
+  ( replicaDelta
+  , legDelta
+  , principalDelta
+  , replicaDeltaLayout
+  ) where
+
+import Graphics.Rendering.Chart.Easy (Layout)
+
+import Greeks.Delta (PayoffDelta(..), PriceDeltaX96(..), deltaOfPayoff, payoffDeltaLayout)
+import Liquidity.LiquidityChunk (LiquidityChunk, chunkAmount0, chunkLiquidity, chunkTickLower, chunkTickUpper)
+import Panoptic.LegChunk (legChunk)
+import Panoptic.MintPlan (MintPlan(..), fourLegNumLegs)
+import Panoptic.NId (panopticTokenType)
+import Payoffs.VolatilityReplica (fourLegReplica)
+import SqrtGrid (PayoffX96(..), SqrtPlot, SqrtPriceX96(..), mulDiv, pattern Q96, sqrtPriceX96)
+
+-- | ∂_P of the chunk principal at p: token0 held = L·(b − p̄)·Q96/(p̄·b), p̄ = clamp(p; a, b).
+-- Staged as `getAmount0ForLiquidity`: mulDiv(L << 96, b − p̄, b) / p̄.
+principalDelta :: LiquidityChunk -> SqrtPriceX96 -> PriceDeltaX96
+principalDelta ch (SqrtPriceX96 p) =
+  let SqrtPriceX96 a = sqrtPriceX96 (chunkTickLower ch)
+      SqrtPriceX96 b = sqrtPriceX96 (chunkTickUpper ch)
+      pc = max a (min p b)
+  in  PriceDeltaX96 (mulDiv (chunkLiquidity ch * Q96) (b - pc) b `div` pc)
+
+-- | ∂_P [H_leg − π^{ΔQ_X}(𝓛𝓒_leg)] for one leg.
+legDelta :: MintPlan -> Int -> SqrtPriceX96 -> PriceDeltaX96
+legDelta plan leg p =
+  let ch = legChunk plan leg
+      PriceDeltaX96 dPrincipal = principalDelta ch p
+      PayoffX96 am0 = chunkAmount0 ch
+      dH | panopticTokenType (mintTokenId plan) (toInteger leg) == 0 = 0
+         | otherwise = am0
+  in  PriceDeltaX96 (dH - dPrincipal)
+
+-- | Δ̂^σ(p) = Σ_leg legDelta.
+replicaDelta :: MintPlan -> PayoffDelta
+replicaDelta plan =
+  PayoffDelta $ \p ->
+    PriceDeltaX96 $ sum
+      [ d | leg <- [0 .. fourLegNumLegs (mintTokenId plan) - 1]
+          , let PriceDeltaX96 d = legDelta plan leg p ]
+
+-- | Closed form vs the generic finite-difference instance on the same axis.
+replicaDeltaLayout :: SqrtPlot -> MintPlan -> SqrtPriceX96 -> Layout Double Double
+replicaDeltaLayout config plan pStar =
+  payoffDeltaLayout config
+    [ ("Δ̂^σ closed form (Σ_leg)", replicaDelta plan)
+    , ("∂_P π̂^σ central difference", deltaOfPayoff (fourLegReplica plan pStar))
+    ]

--- a/src/Plotting/PlotInterest.hs
+++ b/src/Plotting/PlotInterest.hs
@@ -70,6 +70,8 @@ interestFunctionEC config plotY labeledFunctions = do
           fromIntegral
             (unReturnPips
               (mkReturn (interestFunction sample) (savingsPayoff sample)))
+        RawY _ ->
+          payoffToDouble (interestFunction sample)
 
     functionPoints interestFunction =
       [ (interestToDouble sample, yValue sample interestFunction)
@@ -80,6 +82,7 @@ interestFunctionEC config plotY labeledFunctions = do
       case plotY of
         PayoffY -> "PayoffX96"
         ReturnY -> "ReturnPips"
+        RawY unit -> unit
 
   layout_title .= plotTitle config
   layout_x_axis . laxis_title .= xAxisTitle config
@@ -150,6 +153,8 @@ plotInterestTickFunction output config plotY tMin tMax tickFunctions =
             in  fromIntegral
                   (unReturnPips
                     (mkReturn (tickFunction t) (savingsPayoff sr)))
+          RawY _ ->
+            payoffToDouble (tickFunction t)
 
       functionPoints tickFunction =
         [ (interestToDouble (interestSqrtX96 t), yValue t tickFunction)
@@ -160,6 +165,7 @@ plotInterestTickFunction output config plotY tMin tMax tickFunctions =
         case plotY of
           PayoffY -> "PayoffX96"
           ReturnY -> "ReturnPips"
+          RawY unit -> unit
 
     layout_title .= plotTitle config
     layout_x_axis . laxis_title .= xAxisTitle config

--- a/src/Plotting/PlotSqrt.hs
+++ b/src/Plotting/PlotSqrt.hs
@@ -21,7 +21,8 @@ import SqrtGrid
   , toDouble
   )
 
-data PlotY = PayoffY | ReturnY
+-- | RawY: signed EVM word on the y axis (no clamp at 0), with its unit label.
+data PlotY = PayoffY | ReturnY | RawY String
   deriving (Show, Eq)
 
 sqrtFunctionEC
@@ -56,6 +57,8 @@ sqrtFunctionEC config plotY labeledFunctions = do
         ReturnY ->
           fromIntegral
             (unReturnPips (mkReturn (sqrtFunction sample) (linearPayoff sample)))
+        RawY _ ->
+          payoffToDouble (sqrtFunction sample)
 
     functionPoints sqrtFunction =
       [ (toDouble sample, yValue sample sqrtFunction)
@@ -66,6 +69,7 @@ sqrtFunctionEC config plotY labeledFunctions = do
       case plotY of
         PayoffY -> "PayoffX96"
         ReturnY -> "ReturnPips"
+        RawY unit -> unit
 
   layout_title .= plotTitle config
   layout_x_axis . laxis_title .= xAxisTitle config

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -214,6 +214,8 @@ import qualified Payoffs.CLMMPosition as CLMM
 import Payoffs.CLMMPosition (clmmChunk)
 import Panoptic.LegChunk (legChunk, legChunks, legLiquidity)
 import Payoffs.VolatilityReplica (ErrorX96(..), fourLegReplica, legMintValue, replicaError, windowTicks)
+import Greeks.Delta (PayoffDelta(..), PriceDeltaX96(..), deltaOfPayoff)
+import Payoffs.ReplicaDelta (replicaDelta)
 import Panoptic.Binning (binNotionals, binToLegs, ladderFromVolOrder, mintPlanFromLadder, quantizationReport, QuantizationRow(..))
 import qualified Payoffs.PathAccrual as PA
 import Payoffs.LadderPosition
@@ -1187,6 +1189,33 @@ main = do
     replica = fourLegReplica planBig pStar
     at p    = let PayoffX96 y = Payoff.runPayoff replica p in y
   let tolRep = 10 ^ (9 :: Int)  -- 1e-9 of ΔQ_υ = 1e18; X96 floors between branches
+
+  -- TODO #33 (#86): Δ̂^σ = ∂_P π̂^σ (rebate note Def 12, test §5.1).  Closed form
+  -- (Payoffs.ReplicaDelta) vs the generic finite-difference Greeks.Delta instance,
+  -- 0 at p*, sign, nondecreasing (convexity of π̂^σ).
+  let
+    dHat   = runPayoffDelta (replicaDelta planBig)
+    dFD    = runPayoffDelta (deltaOfPayoff replica)
+    dAt f i = let PriceDeltaX96 d = f (sqrtPriceX96 i) in d
+    dH = dAt dHat
+    dF = dAt dFD
+    legEdges = concat [ [chunkTickLower c, chunkTickUpper c] | c <- chunks ]
+    interior i = all (\e -> abs (i - e) > 2) legEdges   -- bump ≈ 0.3 tick; stay > 2 ticks off kinks
+    relTol want got = abs (got - want) <= max (10 ^ (6 :: Int)) (abs want `div` 1000)  -- 1e-3 (bump curvature)
+  sequence_
+    [ if relTol (dH i) (dF i) then pure ()
+        else error ("replicaDelta /= finite difference at tick " ++ show i ++ ": " ++ show (dH i, dF i))
+    | i <- [-60, -40, -25, -17, -12, -7, -3, 3, 7, 12, 17, 25, 40, 60], interior i ]
+  if abs (dAt dHat 0) <= tolRep then putStrLn "ok: replicaDelta(p*) = 0"
+    else error ("replicaDelta(p*) /= 0: " ++ show (dAt dHat 0))
+  sequence_
+    [ if (i < 0 && dAt dHat i <= 0) || (i > 0 && dAt dHat i >= 0) then pure ()
+        else error ("replicaDelta sign wrong at tick " ++ show i)
+    | i <- [-60, -20, -5, 5, 20, 60] ]
+  let ticksMono = [-60, -55 .. 60] :: [Int]
+  if and (zipWith (\i j -> dAt dHat i <= dAt dHat j) ticksMono (drop 1 ticksMono))
+    then putStrLn "ok: replicaDelta nondecreasing (π̂^σ convex)"
+    else error "replicaDelta not nondecreasing"
   if abs (at pStar) <= tolRep then putStrLn "ok: replica(p*) = 0 (X96 tol)"
     else error ("replica(p*) /= 0: " ++ show (at pStar))
   sequence_


### PR DESCRIPTION
## Summary
- Implements TODO.md #33 (feat): `Greeks.Delta` gains the payoff-generic `PayoffDelta`/`PriceDeltaX96` (∂_P of any `Payoff SqrtPriceX96`, central difference in price, raw token0 = ΔV·Q96/ΔP); `Payoffs.ReplicaDelta` is its closed-form instance for `fourLegReplica` (Def 12 of the rebate note): per leg ∂_P principal = amount0 of the chunk on [clamp(p), b], ∂_P H = 0 (put) / amount0 (call)
- `Plotting.PlotSqrt.RawY unit`: signed EVM-word y axis (no clamp at 0) — needed for a signed delta
- Panel `outputs/Payoffs/Replica/panel-replica-delta.png` (outputs/ is gitignored); BITWIDTHS rows for `principalDelta` and `deltaOfPayoff`

## Linked issue
Closes #86

## Test plan
- [x] closed form = finite difference (rel 1e-3) at 14 ticks > 2 ticks off leg edges
- [x] Δ̂^σ(p*) = 0; ≤ 0 below p*, ≥ 0 above; nondecreasing on [−60, 60] (convexity)
- [x] `stack test --ghc-options=-Werror` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb7TAbixYPnsgNMwXJogp8