### PR TITLE
feat(todo-34): Hedge.Ledger — (h, B_s, B_r) and hedgeStep (rebate note Defs 13–14)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -186,6 +186,7 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - Note: `docs/superpowers/specs/2026-08-25-scratchpad-price-update-transfer-design.md` — Prop A (roles), Defs 9–11 (signed \(s\), budget, equilibrium \(\mathrm{LVR}_{\mathrm{net}}=s^\star\nu_{\mathrm{arb}}\)), two-source path (GAMS round trips + external update rule)
    - #34 becomes: trans half = GAMS replay (given \([\nu_{\mathrm{trans}}/\nu]\), \(u\)); arb half = \(P_{\mathrm{ext}}\) + rule at \(s\) (\([\nu_{\mathrm{arb}}/\nu]\) as output). Implementation item next.
 33. **ReplicaDelta — \(\hat\Delta^\sigma=\partial_P\hat\pi^\sigma\) as a `Greeks.Delta` instance on the 4-leg replica (Def 12; rebate-note test §5.1)** — `feat` — [#86](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/86) / [#87](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/87) ✓ merged
+34. **Hedge.Ledger — (h, B_s, B_r), `hedgeStep` (Defs 13–14; rebate-note test §5.2)** — `feat` — [#89](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/89)
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 

--- a/cfmm-scratchpad.cabal
+++ b/cfmm-scratchpad.cabal
@@ -29,6 +29,7 @@ library
       Greeks.Gamma
       Greeks.Theta
       Greeks.Vega
+      Hedge.Ledger
       Lib
       Liquidity.LiquidityChunk
       Liquidity.LiquidityDensity

--- a/docs/BITWIDTHS.md
+++ b/docs/BITWIDTHS.md
@@ -22,6 +22,7 @@ Operand ranges: sqrt prices `a, b, p` ≤ 2^160 (Q64.96); liquidity `L` ≤ 2^12
 | `ErrorX96` | `mulDiv d Q96 N_1`, square, sum, `integerSqrt` | **off-chain only** | unbounded on-chain | no EVM bound claimed |
 | `principalDelta` (∂_P principal = token0 held) | `mulDiv (L·Q96) (b − p̄) b `div` p̄`, p̄ = clamp(p; a, b) | `getAmount0ForLiquidity` at (p̄, b) | `L·Q96` ≤ 2^224 | fits 256; result < 2^128 |
 | `deltaOfPayoff` (generic ∂_P) | `mulDiv (ΔV) Q96 (ΔP)` | **off-chain / tests only** | `ΔV·Q96` ≤ 2^224 | signed; twin is the closed form, not the difference |
+| `hedgeStep` value1 / fee | `mulDiv (mulDiv p p Q96) |q*| Q96`, then `mulDiv value1 φ 1e6` | `getAmountsMoved`-style valuation + fee | `p²` ≤ 2^320; `(p²/Q96)·|q*|` ≤ 2^352 | 512-bit both stages; `q*` < 2^128 |
 | `lnQ96` (Item 1) | port of Solady `lnWad` on `mulDiv p WAD p*`, then `mulDiv (2·ln) Q96 WAD` | `FixedPointMathLib.lnWad` | int256 | signed: floor (Haskell `div`) vs truncate (Solidity `/`) — floor chosen |
 
 Rounding direction: `chunkAmount0/1` round **down**; Panoptic rounds long-closing amounts **up** (`getAmountsMoved`).

--- a/src/Hedge/Ledger.hs
+++ b/src/Hedge/Ledger.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+-- | Hedge ledger — Defs 13–14 of the delta-hedge rebate note
+-- (docs/superpowers/specs/2026-08-25-scratchpad-delta-hedge-rebate-design.md).
+--
+-- State per position: (h, B_s, B_r) = (token0 delta already hedged, streamia paid,
+-- rebates paid), invariant B_r ≤ B_s.  A holder swap moving p_before → p_after
+-- with signed token0 flow q (q > 0: holder receives token0) has target
+-- Δ* = Δ̂^σ(p_after) (Payoffs.ReplicaDelta, raw token0); the qualifying part is
+-- the portion of q that moves h toward Δ*:
+--   q* = sgn(Δ* − h) · min(|q|, |Δ* − h|)  if sgn q = sgn(Δ* − h), else 0.
+-- Rebate ρ = min(φ · value1(q*, p_after), B_s − B_r), value1 = |q*|·P/Q96 in token1;
+-- then h ← h + q*, B_r ← B_r + ρ.  Re-submitting a hedged delta gives q* = 0, ρ = 0.
+-- Amendment to the note's Def 14: q is in token0 (the delta's unit); the fee on it
+-- is valued in token1 at p_after.  All Integer, mulDiv staged (docs/BITWIDTHS.md).
+module Hedge.Ledger
+  ( Ledger(..)
+  , emptyLedger
+  , payStreamia
+  , HolderSwap(..)
+  , RebateX96(..)
+  , qualifying
+  , hedgeStep
+  , ledgerInvariant
+  ) where
+
+import Greeks.Delta (PayoffDelta(..), PriceDeltaX96(..))
+import Pricing.Stremia (FeePips, unFeePips)
+import SqrtGrid (SqrtPriceX96(..), mulDiv, pattern Q96)
+
+data Ledger = Ledger
+  { hedged       :: Integer   -- h, raw token0, signed
+  , streamiaPaid :: Integer   -- B_s, raw token1
+  , rebated      :: Integer   -- B_r, raw token1
+  }
+  deriving (Show, Eq)
+
+emptyLedger :: Ledger
+emptyLedger = Ledger 0 0 0
+
+-- | Streamia accrues to the budget; never decreases it.
+payStreamia :: Integer -> Ledger -> Ledger
+payStreamia s led
+  | s < 0     = error "Hedge.Ledger.payStreamia: streamia must be ≥ 0"
+  | otherwise = led { streamiaPaid = streamiaPaid led + s }
+
+-- | One swap by the position holder.
+data HolderSwap = HolderSwap
+  { swapAfter  :: SqrtPriceX96   -- p_after
+  , swapToken0 :: Integer        -- q, signed raw token0 the holder receives
+  }
+  deriving (Show, Eq)
+
+newtype RebateX96 = RebateX96 Integer
+  deriving (Show, Eq, Ord)
+
+-- | q* of Def 14.
+qualifying :: Integer -> Integer -> Integer -> Integer
+qualifying deltaStar h q
+  | gap == 0 || q == 0        = 0
+  | signum q /= signum gap    = 0
+  | otherwise                 = signum gap * min (abs q) (abs gap)
+  where gap = deltaStar - h
+
+-- | (Ledger, ρ) after the holder's swap; the delta is the payoff's (Def 12 instance).
+hedgeStep :: FeePips -> PayoffDelta -> Ledger -> HolderSwap -> (Ledger, RebateX96)
+hedgeStep phi (PayoffDelta delta) led (HolderSwap pAfter@(SqrtPriceX96 p) q) =
+  let PriceDeltaX96 deltaStar = delta pAfter
+      qStar  = qualifying deltaStar (hedged led) q
+      value1 = mulDiv (mulDiv p p Q96) (abs qStar) Q96      -- |q*| valued in token1 at p_after
+      feeOn  = mulDiv value1 (unFeePips phi) 1000000
+      budget = streamiaPaid led - rebated led
+      rho    = max 0 (min feeOn budget)
+      led'   = led { hedged = hedged led + qStar, rebated = rebated led + rho }
+  in  (led', RebateX96 rho)
+
+ledgerInvariant :: Ledger -> Bool
+ledgerInvariant led = rebated led <= streamiaPaid led && rebated led >= 0

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -216,6 +216,7 @@ import Panoptic.LegChunk (legChunk, legChunks, legLiquidity)
 import Payoffs.VolatilityReplica (ErrorX96(..), fourLegReplica, legMintValue, replicaError, windowTicks)
 import Greeks.Delta (PayoffDelta(..), PriceDeltaX96(..), deltaOfPayoff)
 import Payoffs.ReplicaDelta (replicaDelta)
+import Hedge.Ledger (HolderSwap(..), Ledger(..), RebateX96(..), emptyLedger, hedgeStep, ledgerInvariant, payStreamia, qualifying)
 import Panoptic.Binning (binNotionals, binToLegs, ladderFromVolOrder, mintPlanFromLadder, quantizationReport, QuantizationRow(..))
 import qualified Payoffs.PathAccrual as PA
 import Payoffs.LadderPosition
@@ -1250,6 +1251,35 @@ main = do
             ++ show right
         )
     else putStrLn "ok: gammaCoordinate ratio Theorem 38"
+
+  -- TODO #34: hedge ledger (rebate note Defs 13–14, test §5.2): invariant, no double claim,
+  -- direction rule, cap at |Δ* − h|, budget cap.
+  let
+    phiH    = mkFeePips 3000
+    dHatPD  = replicaDelta planBig
+    led0    = payStreamia (10 ^ (15 :: Int)) emptyLedger          -- B_s = 1e-3 token1
+    p20     = sqrtPriceX96 20
+    dStar20 = dAt dHat 20                                          -- > 0 above p*
+    (led1, RebateX96 r1) = hedgeStep phiH dHatPD led0 (HolderSwap p20 dStar20)
+    (led2, RebateX96 r2) = hedgeStep phiH dHatPD led1 (HolderSwap p20 dStar20)   -- same delta again
+    (led3, RebateX96 r3) = hedgeStep phiH dHatPD led0 (HolderSwap p20 (negate dStar20)) -- wrong direction
+    (led4, _)            = hedgeStep phiH dHatPD led0 (HolderSwap p20 (3 * dStar20))    -- over-hedge capped
+  assertEqual "qualifying: sign rule" 0 (qualifying 10 0 (-5))
+  assertEqual "qualifying: cap at |Δ*−h|" 10 (qualifying 10 0 25)
+  assertEqual "qualifying: partial" (-4) (qualifying (-10) 0 (-4))
+  if r1 > 0 && ledgerInvariant led1 && hedged led1 == dStar20 then putStrLn "ok: hedgeStep rebates a qualifying hedge"
+    else error ("hedgeStep first hedge: " ++ show (led1, r1))
+  assertEqual "hedgeStep: re-submitting hedged delta → ρ = 0" 0 r2
+  assertEqual "hedgeStep: re-submitting → h unchanged" (hedged led1) (hedged led2)
+  assertEqual "hedgeStep: wrong direction → ρ = 0, h unchanged" (0, 0) (r3, hedged led3)
+  assertEqual "hedgeStep: over-hedge capped at Δ*" dStar20 (hedged led4)
+  -- budget cap: tiny streamia, rebate = B_s − B_r exactly, invariant holds
+  let ledTiny = payStreamia 7 emptyLedger
+      (led5, RebateX96 r5) = hedgeStep phiH dHatPD ledTiny (HolderSwap p20 dStar20)
+      (led6, RebateX96 r6) = hedgeStep phiH dHatPD (payStreamia 0 led5) (HolderSwap (sqrtPriceX96 40) (dAt dHat 40))
+  assertEqual "hedgeStep: rebate capped by budget" 7 r5
+  if ledgerInvariant led5 && ledgerInvariant led6 && r6 == 0 then putStrLn "ok: ledger invariant B_r ≤ B_s under exhausted budget"
+    else error ("ledger invariant broken: " ++ show (led5, led6, r6))
 
   _ <- evaluate (gammaCoordinate (unXiX96 xiPinned) eta spacing10 (-10 :: Tick))
   putStrLn "ok: gammaCoordinate negative tick"


### PR DESCRIPTION
## Summary
- Implements TODO.md #34 (feat): `Hedge.Ledger` — `Ledger{hedged,streamiaPaid,rebated}`, `payStreamia`, `qualifying` (q* of Def 14), `hedgeStep φ Δ̂ ledger swap → (ledger', ρ)`, `ledgerInvariant`
- Amendment to the note's Def 14 (documented in the module): q is in token0 (the delta's unit); the fee on q* is valued in token1 at p_after
- BITWIDTHS row for the valuation/fee chain

## Linked issue
Closes #89

## Test plan
- [x] invariant B_r ≤ B_s on every step (incl. exhausted budget)
- [x] re-submitting a hedged delta → ρ = 0, h unchanged
- [x] sign rule, cap at |Δ* − h|, budget cap (ρ = B_s − B_r exactly)
- [x] `stack test --ghc-options=-Werror` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb7TAbixYPnsgNMwXJogp8