### PR TITLE
feat(todo-35): HolderPath — composed path, hedgeAlong (Prop B), [ν_arb/ν] as output; tests §5.3–5.5

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -186,7 +186,8 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - Note: `docs/superpowers/specs/2026-08-25-scratchpad-price-update-transfer-design.md` — Prop A (roles), Defs 9–11 (signed \(s\), budget, equilibrium \(\mathrm{LVR}_{\mathrm{net}}=s^\star\nu_{\mathrm{arb}}\)), two-source path (GAMS round trips + external update rule)
    - #34 becomes: trans half = GAMS replay (given \([\nu_{\mathrm{trans}}/\nu]\), \(u\)); arb half = \(P_{\mathrm{ext}}\) + rule at \(s\) (\([\nu_{\mathrm{arb}}/\nu]\) as output). Implementation item next.
 33. **ReplicaDelta — \(\hat\Delta^\sigma=\partial_P\hat\pi^\sigma\) as a `Greeks.Delta` instance on the 4-leg replica (Def 12; rebate-note test §5.1)** — `feat` — [#86](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/86) / [#87](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/87) ✓ merged
-34. **Hedge.Ledger — (h, B_s, B_r), `hedgeStep` (Defs 13–14; rebate-note test §5.2)** — `feat` — [#89](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/89)
+34. **Hedge.Ledger — (h, B_s, B_r), `hedgeStep` (Defs 13–14; rebate-note test §5.2)** — `feat` — [#89](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/89) / [#90](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/90) ✓ merged
+35. **HolderPath — composed path (trans / holder / residual arb), `hedgeAlong` (Prop B), \([\nu_{\mathrm{arb}}/\nu]\) as output; rebate-note tests §5.3–5.5; re-scoped #34 (TODO #23) closed** — `feat` — [#91](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/91)
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -55,6 +55,7 @@ import Payoffs.Forward (AtmForward(..))
 import Payoffs.Log (nakedLogQ96, nakedLogTickQ96)
 import Panoptic.NId (MintPlan(..), fourLegSkeleton, mkNId, volOrderToMintPlan)
 import Payoffs.ReplicaDelta (replicaDeltaLayout)
+import Payoffs.HolderPath (Regime(..), arbShare, composedPath)
 import Payoffs.VolatilityReplica (ErrorX96(..), legsLayout, replicaError, replicaLayout, windowTicks)
 import Panoptic.Binning (binToLegs, ladderFromVolOrder, mintPlanFromLadder, quantizationReport)
 import Payoffs.LadderPosition (ladderN1, ladderT1)
@@ -442,6 +443,16 @@ main = do
   writePanel
     "outputs/Payoffs/Replica/panel-replica-delta.png"
     (Cell (replicaDeltaLayout deltaCfg replicaPlan pStar0))
+
+  -- TODO #35: [ν_arb/ν] as an OUTPUT of the update rule — pips vs fee band (ticks),
+  -- holder active (gas = 1 tick) vs inactive.  Axes: ticks, pips (uint24).
+  let shareLine active =
+        [ (toInteger band, PA.unArbSharePips (arbShare (composedPath 5 0 400 3 4 (Regime 1 band active))))
+        | band <- [0, 2 .. 40] ]
+  writePanel
+    "outputs/Payoffs/Accrual/panel-arbshare-vs-band.png"
+    (Cell (PA.linesLayout "[ν_arb/ν] read off the composed path (trans ±3, ext ±4 ticks/round)" "fee band (ticks)" "arb share (pips)"
+             [ ("holder inactive", shareLine False), ("holder active, gas = 1 tick", shareLine True) ]))
 
   -- TODO #28.2: T1 geometric ladder (S = 4000, Δ = 10, ι = 400, ξ*) — README § REPLICATION_THEORY
   -- Theorem 10 overlay (same units: T1/N_1 vs c(S)·logPortfolio), residual, rung density.

--- a/cfmm-scratchpad.cabal
+++ b/cfmm-scratchpad.cabal
@@ -44,6 +44,7 @@ library
       Payoffs.CLMMPosition
       Payoffs.CoveredCall
       Payoffs.Forward
+      Payoffs.HolderPath
       Payoffs.LadderPosition
       Payoffs.Linear
       Payoffs.Log

--- a/src/Hedge/Ledger.hs
+++ b/src/Hedge/Ledger.hs
@@ -5,7 +5,8 @@
 --
 -- State per position: (h, B_s, B_r) = (token0 delta already hedged, streamia paid,
 -- rebates paid), invariant B_r ≤ B_s.  A holder swap moving p_before → p_after
--- with signed token0 flow q (q > 0: holder receives token0) has target
+-- with signed token0 flow q (q > 0: holder SELLS token0 to the pool — the hedge of a
+-- long-convexity position above p*, where Δ̂^σ > 0) has target
 -- Δ* = Δ̂^σ(p_after) (Payoffs.ReplicaDelta, raw token0); the qualifying part is
 -- the portion of q that moves h toward Δ*:
 --   q* = sgn(Δ* − h) · min(|q|, |Δ* − h|)  if sgn q = sgn(Δ* − h), else 0.
@@ -47,7 +48,7 @@ payStreamia s led
 -- | One swap by the position holder.
 data HolderSwap = HolderSwap
   { swapAfter  :: SqrtPriceX96   -- p_after
-  , swapToken0 :: Integer        -- q, signed raw token0 the holder receives
+  , swapToken0 :: Integer        -- q, signed raw token0 the holder sells to the pool
   }
   deriving (Show, Eq)
 

--- a/src/Payoffs/HolderPath.hs
+++ b/src/Payoffs/HolderPath.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+-- | Holder-hedged path (rebate note §3–§5; TODO #35, re-scoped #34 / TODO #23).
+--
+-- Three sources on one tick path:
+--   trans  — round-trip noise (the GAMS half; fees, no correction);
+--   holder — the position holder moves the pool to the external tick when the
+--            gap exceeds the gas threshold (fee-free at the margin: rebate);
+--   arb    — residual: closes gaps the holder left, only beyond the fee band.
+-- The arb share [ν_arb/ν] is READ OFF the produced path (tick volume), never set.
+--
+-- Hedging along a path (Prop B): at each step end the holder brings h → Δ̂^σ(p)
+-- when |Δ̂^σ(p) − h| > gas (token0); the hedge trade is assumed small against
+-- the pool (no own price impact).  Per step, gamma gain
+--   γ_k = [π̂^σ(p_{k+1}) − π̂^σ(p_k)] − h_k · (P_{k+1} − P_k)/Q96   (≥ 0 when h_k = Δ̂^σ(p_k))
+-- so that holder P&L = Σγ − fees paid + rebates − streamia paid.
+module Payoffs.HolderPath
+  ( Regime(..)
+  , composedPath
+  , pathEndTicks
+  , arbShare
+  , HolderReport(..)
+  , hedgeAlong
+  , holderPnL
+  , trianglePath
+  ) where
+
+import Greeks.Delta (PayoffDelta(..), PriceDeltaX96(..))
+import Hedge.Ledger (HolderSwap(..), Ledger(..), RebateX96(..), hedgeStep)
+import Panoptic.MintPlan (MintPlan)
+import Payoffs.PathAccrual (ArbSharePips, Step(..), Tag(..), mkArbSharePips, pattern PIPS_ONE)
+import qualified Payoffs.Payoff as Payoff
+import Payoffs.ReplicaDelta (replicaDelta)
+import Payoffs.VolatilityReplica (fourLegReplica)
+import Pricing.Stremia (FeePips, unFeePips)
+import SqrtGrid (PayoffX96(..), SqrtPriceX96(..), Tick, mulDiv, pattern Q96, sqrtPriceX96)
+
+data Regime = Regime
+  { rgGasTicks     :: Int    -- holder corrects when |e − p| > gas
+  , rgBandTicks    :: Int    -- residual arb corrects when |e − p| > band
+  , rgHolderActive :: Bool
+  }
+  deriving (Show, Eq)
+
+-- | Deterministic composed path: n rounds of (trans ±transAmp, external ±extAmp,
+-- then holder / arb correction per the regime).  Same 32-bit LCG as syntheticPath.
+composedPath :: Int -> Tick -> Int -> Int -> Int -> Regime -> [Step]
+composedPath seed i0 n transAmp extAmp rg = go 0 i0 i0 (fromIntegral seed :: Integer)
+  where
+    lcg st = (1664525 * st + 1013904223) `mod` 4294967296
+    go k p e st
+      | k >= n = []
+      | otherwise =
+          let st1 = lcg st
+              st2 = lcg st1
+              p'  = if (st1 `div` 65536) `mod` 2 == 0 then p + transAmp else p - transAmp
+              e'  = if (st2 `div` 65536) `mod` 2 == 0 then e + extAmp else e - extAmp
+              gap = abs (e' - p')
+              trans = Step p p' Trans
+              (corr, pEnd)
+                | rgHolderActive rg && gap > rgGasTicks rg  = ([Step p' e' Holder], e')
+                | gap > rgBandTicks rg                      = ([Step p' e' Arb], e')
+                | otherwise                                 = ([], p')
+          in  trans : corr ++ go (k + 1) pEnd e' st2
+
+-- | Tick after each step (the ticks at which the holder may hedge).
+pathEndTicks :: [Step] -> [Tick]
+pathEndTicks = map stepTo
+
+-- | [ν_arb/ν] read off the path: arb tick volume over total tick volume, pips.
+arbShare :: [Step] -> ArbSharePips
+arbShare steps =
+  let vol tag = sum [ toInteger (abs (stepTo s - stepFrom s)) | s <- steps, stepTag s == tag ]
+      total = vol Trans + vol Arb + vol Holder
+  in  mkArbSharePips (if total == 0 then 0 else mulDiv (vol Arb) PIPS_ONE total)
+
+data HolderReport = HolderReport
+  { rpGamma    :: Integer   -- Σγ_k, token1
+  , rpFeesPaid :: Integer   -- φ on every hedge trade, token1
+  , rpRebates  :: Integer   -- Σρ, token1
+  , rpHedges   :: Int
+  , rpLedger   :: Ledger
+  }
+  deriving (Show, Eq)
+
+-- | Hedge the replica along the path; gas in raw token0.
+hedgeAlong :: FeePips -> MintPlan -> Integer -> Ledger -> [Step] -> HolderReport
+hedgeAlong phi plan gasToken0 led0 steps = go led0 (HolderReport 0 0 0 0 led0) steps
+  where
+    pStar = sqrtPriceX96 0
+    replica = Payoff.runPayoff (fourLegReplica plan pStar)
+    PayoffDelta delta = replicaDelta plan
+    priceOf (SqrtPriceX96 p) = mulDiv p p Q96
+    go led rep [] = rep { rpLedger = led }
+    go led rep (Step iFrom iTo _ : rest) =
+      let pF = sqrtPriceX96 iFrom
+          pT = sqrtPriceX96 iTo
+          PayoffX96 vF = replica pF
+          PayoffX96 vT = replica pT
+          gammaK = (vT - vF) - mulDiv (hedged led) (priceOf pT - priceOf pF) Q96
+          PriceDeltaX96 dStar = delta pT
+          q = dStar - hedged led
+          (led', fee, rho, n)
+            | abs q > gasToken0 =
+                let SqrtPriceX96 p = pT
+                    value1 = mulDiv (mulDiv p p Q96) (abs q) Q96
+                    f = mulDiv value1 (unFeePips phi) 1000000
+                    (l', RebateX96 r) = hedgeStep phi (PayoffDelta delta) led (HolderSwap pT q)
+                in  (l', f, r, 1)
+            | otherwise = (led, 0, 0, 0)
+      in  go led' rep { rpGamma = rpGamma rep + gammaK
+                      , rpFeesPaid = rpFeesPaid rep + fee
+                      , rpRebates = rpRebates rep + rho
+                      , rpHedges = rpHedges rep + n } rest
+
+-- | Σγ − fees + rebates − streamia (Prop B).
+holderPnL :: HolderReport -> Integer
+holderPnL rep = rpGamma rep - rpFeesPaid rep + rpRebates rep - streamiaPaid (rpLedger rep)
+
+-- | Round trip i0 → i0 + amp → i0 − amp → i0 in Trans steps of `stride` ticks (p_0 = p_T).
+trianglePath :: Tick -> Int -> Int -> [Step]
+trianglePath i0 amp stride =
+  let up   = [i0, i0 + stride .. i0 + amp]
+      down = [i0 + amp, i0 + amp - stride .. i0 - amp]
+      back = [i0 - amp, i0 - amp + stride .. i0]
+      pts  = up ++ drop 1 down ++ drop 1 back
+  in  zipWith (\a b -> Step a b Trans) pts (drop 1 pts)

--- a/src/Payoffs/PathAccrual.hs
+++ b/src/Payoffs/PathAccrual.hs
@@ -45,7 +45,11 @@ import Panoptic.MintPlan (MintPlan)
 import Pricing.Stremia (FeePips, unFeePips)
 import SqrtGrid (PayoffX96(..), SqrtPriceX96(..), Tick, mulDiv, pattern Q96, sqrtPriceX96)
 
-data Tag = Trans | Arb
+-- | Holder = the position holder correcting the pool toward the external price
+-- (rebate note §3).  To the LP's book a holder correction accrues like an arb
+-- correction (fee + concavity gap); who receives the gap is tracked in
+-- Payoffs.HolderPath, not here.
+data Tag = Trans | Arb | Holder
   deriving (Show, Eq)
 
 -- | One price move on the path with its flow tag.
@@ -118,8 +122,9 @@ stepAccrual phiX phiM ch (Step iFrom iTo tag)
                   else mulDiv amt0AtPj (unFeePips phiX) 1000000
           lvr = if goingUp then amt0AtPj - amt1 else amt1 - amt0AtPj
       in  case tag of
-            Trans -> Accrual fee 0 0
-            Arb   -> Accrual 0 fee (max 0 lvr)
+            Trans  -> Accrual fee 0 0
+            Arb    -> Accrual 0 fee (max 0 lvr)
+            Holder -> Accrual 0 fee (max 0 lvr)
   where
     goingUp = iTo > iFrom
     SqrtPriceX96 a = sqrtPriceX96 (chunkTickLower ch)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -216,6 +216,7 @@ import Panoptic.LegChunk (legChunk, legChunks, legLiquidity)
 import Payoffs.VolatilityReplica (ErrorX96(..), fourLegReplica, legMintValue, replicaError, windowTicks)
 import Greeks.Delta (PayoffDelta(..), PriceDeltaX96(..), deltaOfPayoff)
 import Payoffs.ReplicaDelta (replicaDelta)
+import Payoffs.HolderPath (HolderReport(..), Regime(..), arbShare, composedPath, hedgeAlong, holderPnL, pathEndTicks, trianglePath)
 import Hedge.Ledger (HolderSwap(..), Ledger(..), RebateX96(..), emptyLedger, hedgeStep, ledgerInvariant, payStreamia, qualifying)
 import Panoptic.Binning (binNotionals, binToLegs, ladderFromVolOrder, mintPlanFromLadder, quantizationReport, QuantizationRow(..))
 import qualified Payoffs.PathAccrual as PA
@@ -1280,6 +1281,43 @@ main = do
   assertEqual "hedgeStep: rebate capped by budget" 7 r5
   if ledgerInvariant led5 && ledgerInvariant led6 && r6 == 0 then putStrLn "ok: ledger invariant B_r ≤ B_s under exhausted budget"
     else error ("ledger invariant broken: " ++ show (led5, led6, r6))
+
+  -- TODO #35: holder path (rebate note §5.3–5.5).
+  -- 5.3 round trip (Trans only): LVR = 0, fees > 0, replica back to start, rebates = fees
+  -- paid (every hedge qualifying, budget ample), Σγ ≥ 0.
+  let
+    tri      = trianglePath 0 40 5
+    accTri   = foldr PA.addAccrual PA.zeroAccrual (PA.planAccrual phiXp phiMp planBig tri)
+    ledAmple = payStreamia (10 ^ (24 :: Int)) emptyLedger
+    repTri   = hedgeAlong phiH planBig 0 ledAmple tri
+    atRep p  = let PayoffX96 y = Payoff.runPayoff replica (sqrtPriceX96 p) in y
+  assertEqual "5.3 round trip: LVR_gross = 0" 0 (PA.lvrGross accTri)
+  if PA.feesTrans accTri > 0 then putStrLn "ok: 5.3 round trip fees > 0" else error "5.3 no fees"
+  assertEqual "5.3 round trip: p_T = p_0" 0 (last (pathEndTicks tri))
+  assertEqual "5.3 round trip: replica back to start" (atRep 0) (atRep (last (pathEndTicks tri)))
+  assertEqual "5.3 rebates = fees on qualifying hedges (ample budget)" (rpFeesPaid repTri) (rpRebates repTri)
+  if rpGamma repTri >= 0 && rpHedges repTri > 0 then putStrLn ("ok: 5.3 Σγ ≥ 0 over " ++ show (rpHedges repTri) ++ " hedges")
+    else error ("5.3 gamma: " ++ show repTri)
+  assertEqual "5.3 holder P&L = Σγ − B_s (rebates offset fees)" (rpGamma repTri - 10 ^ (24 :: Int)) (holderPnL repTri)
+  -- 5.4 convergence: coarser hedging (stride m) leaves more un-hedged convexity — Σγ nondecreasing in m, all ≥ 0.
+  let gammaAt m = rpGamma (hedgeAlong phiH planBig 0 ledAmple (trianglePath 0 40 m))
+      gs = map gammaAt [1, 2, 4, 8]
+  if and (zipWith (<=) gs (drop 1 gs)) && all (>= 0) gs then putStrLn ("ok: 5.4 Σγ nondecreasing in hedge stride " ++ show gs)
+    else error ("5.4 gamma vs stride: " ++ show gs)
+  -- 5.5 stale mark: holder active (gas = 1 tick) keeps |e − p| ≤ 1 after every round and leaves no
+  -- arb volume; holder inactive lets the gap reach the band, arb share > 0 read off the path.
+  let
+    rgOn  = Regime 1 30 True
+    rgOff = Regime 1 30 False
+    maxGap rg = maximum (0 : [ abs (PA.stepTo s - PA.stepFrom s) | s <- composedPath 5 0 300 3 4 rg, PA.stepTag s /= PA.Trans ])
+    -- a correction step's size IS the gap at that round (the pool sits at e after it)
+  assertEqual "5.5 holder active: no residual arb volume" 0 (PA.unArbSharePips (arbShare (composedPath 5 0 300 3 4 rgOn)))
+  if PA.unArbSharePips (arbShare (composedPath 5 0 300 3 4 rgOff)) > 0 then putStrLn "ok: 5.5 holder inactive: arb share > 0 (output)"
+    else error "5.5 no arb volume without holder"
+  if maxGap rgOn <= 1 + 2 * 4 + 3 then putStrLn "ok: 5.5 holder corrections are at most one round of drift"
+    else error ("5.5 holder gap " ++ show (maxGap rgOn))
+  if maxGap rgOff > maxGap rgOn then putStrLn ("ok: 5.5 stale zone without holder: max correction " ++ show (maxGap rgOff) ++ " vs " ++ show (maxGap rgOn))
+    else error ("5.5 gaps: " ++ show (maxGap rgOff, maxGap rgOn))
 
   _ <- evaluate (gammaCoordinate (unXiX96 xiPinned) eta spacing10 (-10 :: Tick))
   putStrLn "ok: gammaCoordinate negative tick"


### PR DESCRIPTION
## Summary
- Implements TODO.md #35 (feat): `Payoffs.HolderPath` — `composedPath` (trans ± / external ± / holder correction above gas / residual arb above band), `arbShare` read off the path in pips, `hedgeAlong` (ledger stepping with per-step gamma gains, fees, rebates), `holderPnL` (Prop B), `trianglePath`
- `Payoffs.PathAccrual.Tag` gains `Holder` (accrues like Arb on the LP book; recipient tracked in HolderPath)
- Panel `outputs/Payoffs/Accrual/panel-arbshare-vs-band.png` (ticks × pips)
- TODO #34 ticked

## Linked issue
Closes #91
Closes #34 — the re-scoped arb half is the residual of the holder rule; trans half remains the GAMS replay (fees only)

## Test plan
- [x] §5.3 round trip: LVR = 0, fees > 0, replica back to start, rebates = fees paid, Σγ ≥ 0 (16 hedges), P&L = Σγ − B_s
- [x] §5.4 Σγ nondecreasing in hedge stride m ∈ {1,2,4,8} (≈ m×: O(Δi))
- [x] §5.5 holder active ⇒ arb share 0 and corrections ≤ one round of drift; inactive ⇒ share > 0 as output, corrections up to 37 ticks (band 30)
- [x] `stack test --ghc-options=-Werror`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb7TAbixYPnsgNMwXJogp8