### PR TITLE
feat(todo-26/36): λ_{X/M} derived (Prop 4), χ = amount0 (Prop 3) — Payoffs.LvrRate, ex-post check, spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,9 @@ Proof shape: rung edges geometric; primitive \(W(p,t)=\ln t + p^2/(2t^2)\); tele
 
 **Proposition 2 (off-midpoint strike).** Theorem 10 with \(i^\star\) at an arbitrary rung (skew \(\ne\tfrac12\)) — pending.
 
-**Proposition 3 (\(\chi\) from the gamma carrier).** \(\chi(\mathcal{LC}) = \int_{a^2}^{b^2} -\tfrac12 L\,\Gamma_\varphi(P)\,dP\) is the in-range gamma exposure entering \(\lambda_{X/M}\) (MODEL_CLOSURE §2, issue #51) — to be stated via Theorem 5.
+**Proposition 3 (\(\chi\) from the gamma carrier — closed).** \(\int_{a^2}^{b^2} -\tfrac12 L\,\Gamma_\varphi(P)\,dP = \partial_P\pi(b^2)-\partial_P\pi(a^2) = -\,\mathrm{amount0}(\mathcal{LC})\) by Theorem 5 and the principal's price-delta \(\partial_P\pi^{\Delta Q_X} = \mathrm{amount0}(L,\bar p,b)\) (`Payoffs.ReplicaDelta.principalDelta`, the per-leg component of Definition 12). Convention \(\chi := \mathrm{amount0} > 0\) (`Payoffs.LvrRate.chi`). Checked by finite differences of the payoff; Lean twin `chi_eq_amount0` pending (peer C1–C2).
+
+**Proposition 4 (LVR rate per correction segment — derived; issue #51).** On a segment \([lo,hi]\) of a chunk marked at the corrected price \(p_j\): \(\mathrm{LVR}_{\mathrm{net}} = \mathrm{amount}_{in}\,[\rho-\phi]\), \(\rho = p_j^2/(lo\,hi)-1\) (up) or \((lo\,hi)/p_j^2-1\) (down), both token sides; when the segment ends at \(p_j\), \(\rho = r_{1/2}-1\), the sqrt-price return of the correction. So \(\lambda_{X/M} = r_{1/2}-1-\phi_{X/M}\) per unit arb volume: zero at a gap of \(2\phi\) ticks, slope 1 beyond. The MODEL_CLOSURE §2 form \(\phi(2e^{u/2}-1)^{+} = (\sigma_{IV}-\phi)^{+}\) is this under the *identification* \(\sigma_{IV}\equiv r_{1/2}-1\) (a relabeling; the map from the transactional \(u\) is open). Clipped segments (\(p_j\) beyond the chunk) follow the general \(\rho\); a narrow leg can be net-negative on the tail of a wide correction. Spec `docs/superpowers/specs/2026-08-25-scratchpad-lambda-xm-lvr-rate-design.md`; regressions on continuous liquidity (6 seeds × 3 amps × 3 fees: crossing window, \(\ge0\) under the rational band \(2\phi\), slope 1); `panel-lvr-rate-vs-step.png`.
 
 ### Corollaries (what replaces tuning)
 
@@ -559,7 +561,7 @@ Exact functional forms for \(\pi^{\phi}(\pi^{\Delta Q}_{\mathrm{trans}}(r^{e}_{\
 	\end{aligned}
 \]
 
-> DESIGN CLAIM — not derived; needs the #24 CLMM identity and an Aristotle / empirical check. Convention: LVR is the arb's **after-fee** profit, so the fee paid by arbs is netted inside \(\lambda_{X/M}\) and \(\pi^{\phi}\) stays transactional-only.
+> **Derived (Proposition 4, 2026-08-25):** \(\lambda_{X/M} = \rho-\phi_{X/M}\) per unit arb volume on each correction segment, \(\rho = r_{1/2}-1\) (sqrt-price return) when the segment ends at the corrected price; rational corrections need gaps \(>2\phi\) ticks. \(\chi = \mathrm{amount0}\) (Proposition 3) enters through \(\mathrm{amount}_{in}\). The form above holds under the identification \(\sigma_{IV}\equiv r_{1/2}-1\) (the anchor's \(2\phi e^{u/2}\) with the transactional \(u\) is NOT derived from it). \(\lambda_X,\lambda_M\) are no longer primitives. Convention unchanged: LVR is the arb's **after-fee** profit; \(\pi^{\phi}\) stays transactional-only. Under the rebate the correction is the holder's at \(\phi_{\mathrm{eff}}=0\).
 
 **3. Closure.** Every symbol on the right is observed or defined above except \(\lambda_X, \lambda_M\); the tax enters only through the bracket:
 

--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,7 @@ Workflow: see `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (classify → branch → iss
 | 1 | #35 (TODO 24) | \(\chi(\mathcal{LC})\) via per-tick CLMM identity | `CLMMPosition` witness test → Aristotle |
 | 2 | #36 (TODO 25 `feat`) | four \(\mathcal{LC}_{\mathrm{leg}}\), \(\mathrm{or}(\mathrm{leg})\to L_{\mathrm{leg}}\) in Haskell | Hop B vs 4-leg sum |
 | 3 | #34 (TODO 23) + TODO 19/20 | \(u\), atomic \([\nu_{\mathrm{arb}}/\nu]\), \(\sigma_{IV}=2\phi e^{u/2}\) | `volume_path.gms` golden table |
-| 4 | #51 (TODO 26) | the claim: spec → ex-post LVR check → Aristotle statement | needs 1–3; Lean workspace (parent Phase 3) |
+| 4 | #51 (TODO 26) | the claim: spec → ex-post LVR check → Aristotle statement | **derived** (Prop 4, TODO #36); Lean statement with the peer |
 | 5 | #3 (TODO 7) | \(r^{\phi}=\phi\delta_{\mathrm{trans}}\) — fee side of §3 | after 3 |
 | 6 | #31 (TODO 21 Slice 2) | \(r^e_{\mathrm{arb}}=\Lambda(\gamma(u-u^\star))\) — mixture weight | after 3 |
 | 7 | #28 (TODO 22) | ex-ante price of the bracket — downgraded | after 6 |
@@ -188,6 +188,7 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
 33. **ReplicaDelta — \(\hat\Delta^\sigma=\partial_P\hat\pi^\sigma\) as a `Greeks.Delta` instance on the 4-leg replica (Def 12; rebate-note test §5.1)** — `feat` — [#86](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/86) / [#87](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/87) ✓ merged
 34. **Hedge.Ledger — (h, B_s, B_r), `hedgeStep` (Defs 13–14; rebate-note test §5.2)** — `feat` — [#89](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/89) / [#90](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/90) ✓ merged
 35. **HolderPath — composed path (trans / holder / residual arb), `hedgeAlong` (Prop B), \([\nu_{\mathrm{arb}}/\nu]\) as output; rebate-note tests §5.3–5.5; re-scoped #34 (TODO #23) closed** — `feat` — [#91](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/91) / [#92](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/92) ✓ merged
+36. **λ_{X/M} derived (Prop 4) + χ = amount0 (Prop 3) — `Payoffs.LvrRate`, ex-post panel, spec; closes the MODEL_CLOSURE §2 design claim (TODO #26 / #51)** — `feat` — [#51](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/51)
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -56,6 +56,7 @@ import Payoffs.Log (nakedLogQ96, nakedLogTickQ96)
 import Panoptic.NId (MintPlan(..), fourLegSkeleton, mkNId, volOrderToMintPlan)
 import Payoffs.ReplicaDelta (replicaDeltaLayout)
 import Payoffs.HolderPath (Regime(..), arbShare, composedPath)
+import Payoffs.LvrRate (lvrRateLayout, lvrRateOn, naiveBandTicks, rationalBandTicks)
 import Payoffs.VolatilityReplica (ErrorX96(..), legsLayout, replicaError, replicaLayout, windowTicks)
 import Panoptic.Binning (binToLegs, ladderFromVolOrder, mintPlanFromLadder, quantizationReport)
 import Payoffs.LadderPosition (ladderN1, ladderT1)
@@ -453,6 +454,19 @@ main = do
     "outputs/Payoffs/Accrual/panel-arbshare-vs-band.png"
     (Cell (PA.linesLayout "[ν_arb/ν] read off the composed path (trans ±3, ext ±4 ticks/round)" "fee band (ticks)" "arb share (pips)"
              [ ("holder inactive", shareLine False), ("holder active, gas = 1 tick", shareLine True) ]))
+
+  -- TODO #26 (#51): λ_{X/M} ex post — LVR_net per arb tick vs external step, three fee levels.
+  -- Naive band φ crosses zero at s = 2φ ticks; rational band 2φ is ≥ 0 (Prop 4 and its corollary).
+  let chWideP = createChunk (-4000) 4000 (10 ^ (20 :: Int))
+      phiW    = mkFeePips 1000
+      wideLine band = [ (toInteger sv, lvrRateOn 5 0 600 2 phiW band [chWideP] sv) | sv <- [2, 4 .. 60] ]
+  writePanel
+    "outputs/Payoffs/Accrual/panel-lvr-rate-vs-step.png"
+    (Beside
+      (Cell (lvrRateLayout 5 0 600 2 replicaPlan (map mkFeePips [1000, 2000]) [2, 4 .. 60]))
+      (Cell (PA.linesLayout "continuous liquidity (one chunk over the path), φ = 1000 pips" "external step s (ticks / round)" "LVR_net / Σ amount_in (pips)"
+               [ ("band φ (naive): crosses at 2φ = 20 ticks", wideLine (naiveBandTicks phiW))
+               , ("band 2φ (rational): ≥ 0", wideLine (rationalBandTicks phiW)) ])))
 
   -- TODO #28.2: T1 geometric ladder (S = 4000, Δ = 10, ι = 400, ξ*) — README § REPLICATION_THEORY
   -- Theorem 10 overlay (same units: T1/N_1 vs c(S)·logPortfolio), residual, rung density.

--- a/cfmm-scratchpad.cabal
+++ b/cfmm-scratchpad.cabal
@@ -48,6 +48,7 @@ library
       Payoffs.LadderPosition
       Payoffs.Linear
       Payoffs.Log
+      Payoffs.LvrRate
       Payoffs.PathAccrual
       Payoffs.Payoff
       Payoffs.RangeAccrualNote

--- a/docs/BITWIDTHS.md
+++ b/docs/BITWIDTHS.md
@@ -23,6 +23,7 @@ Operand ranges: sqrt prices `a, b, p` ≤ 2^160 (Q64.96); liquidity `L` ≤ 2^12
 | `principalDelta` (∂_P principal = token0 held) | `mulDiv (L·Q96) (b − p̄) b `div` p̄`, p̄ = clamp(p; a, b) | `getAmount0ForLiquidity` at (p̄, b) | `L·Q96` ≤ 2^224 | fits 256; result < 2^128 |
 | `deltaOfPayoff` (generic ∂_P) | `mulDiv (ΔV) Q96 (ΔP)` | **off-chain / tests only** | `ΔV·Q96` ≤ 2^224 | signed; twin is the closed form, not the difference |
 | `hedgeStep` value1 / fee | `mulDiv (mulDiv p p Q96) |q*| Q96`, then `mulDiv value1 φ 1e6` | `getAmountsMoved`-style valuation + fee | `p²` ≤ 2^320; `(p²/Q96)·|q*|` ≤ 2^352 | 512-bit both stages; `q*` < 2^128 |
+| `stepVolume1` / `lvrRateOn` | `mulDiv (mulDiv pj pj Q96) amt0 Q96`; `mulDiv net PIPS_ONE nuArb` | `getAmountsMoved` valuation; off-chain rate | `pj²` ≤ 2^320; `net·1e6` ≤ 2^148 | rate is a uint24-pips view, signed off-chain |
 | `lnQ96` (Item 1) | port of Solady `lnWad` on `mulDiv p WAD p*`, then `mulDiv (2·ln) Q96 WAD` | `FixedPointMathLib.lnWad` | int256 | signed: floor (Haskell `div`) vs truncate (Solidity `/`) — floor chosen |
 
 Rounding direction: `chunkAmount0/1` round **down**; Panoptic rounds long-closing amounts **up** (`getAmountsMoved`).

--- a/docs/superpowers/specs/2026-08-25-scratchpad-lambda-xm-lvr-rate-design.md
+++ b/docs/superpowers/specs/2026-08-25-scratchpad-lambda-xm-lvr-rate-design.md
@@ -1,0 +1,67 @@
+# Scratchpad — λ_{X/M}: the per-token LVR rate, derived (closes the MODEL_CLOSURE §2 design claim)
+
+**Date:** 2026-08-25  
+**Status:** design note + ex-post check; issue #51 (TODO #26 → #36). Two-reviewer pass done (Reality Checker, Model QA); all BLOCKER/MAJOR findings resolved in this version.  
+**Notation anchor:** `VOLATILITY_INSTRUMENTS.md`; README § REPLICATION_THEORY (Thm 5, Prop 3, Prop 4), § CHANNEL_STATICS, § MODEL_CLOSURE §2
+
+## 1. The claim
+
+README MODEL_CLOSURE §2 posited
+\[
+\lambda_{X/M}(u,\phi_{X/M};\mathcal{LC}_{\mathrm{leg}}) \overset{?}{=} \phi_{X/M}\,(2e^{u/2}-1)^{+}\,\chi(\mathcal{LC}_{\mathrm{leg}}),
+\]
+zero until \(\sigma_{IV}/\phi = 2e^{u/2} > 1\), linear beyond, \(\chi\) = in-range exposure. Two objects were open: \(\chi\), and the functional form. §2 closes \(\chi\) exactly; §3 derives the form as an identity of the accrual accounting and states precisely which symbol of the claim is a derivation and which is an identification.
+
+## 2. χ is exact (Proposition 3)
+
+Theorem 5: \(\partial^2_P \pi^{\Delta Q_X} = -\tfrac12 L\,\Gamma_\varphi(P)\) on \(a^2<P<b^2\). The principal's price-delta (the per-leg component of Def 12, `Payoffs.ReplicaDelta.principalDelta`) is \(\partial_P \pi^{\Delta Q_X}(\mathcal{LC};P) = \mathrm{amount0}(L,\bar p,b)\), \(\bar p=\operatorname{clamp}(p;a,b)\): the token0 the chunk holds at \(p\). By the fundamental theorem of calculus,
+\[
+\int_{a^2}^{b^2} -\tfrac12 L\,\Gamma_\varphi\,dP \;=\; \partial_P\pi(b^2) - \partial_P\pi(a^2) \;=\; -\,\mathrm{amount0}(\mathcal{LC}).
+\]
+**Convention.** \(\chi(\mathcal{LC}) := \mathrm{amount0}(\mathcal{LC}) > 0\) (raw token0), so the integral equals \(-\chi\): \(\chi\) is the total delta the chunk sheds across its range. `Payoffs.LvrRate.chi = chunkAmount0`.
+
+Status: the identity `chi = principalDelta(a) − principalDelta(b)` is a consistency check of one formula against itself; the **independent** check is `∫∂²π dP ≈ −χ` with deltas taken by finite differences of the payoff (`deltaOfPayoff` on `CLMMPosition.fromChunk`), test "Prop 3 ∫∂²π dP". The proof is the pending Lean `chi_eq_amount0` from `principal_price_deriv` (`lean4-spec/scratch/peer-from-scratchpad-chi.md`, C1–C2).
+
+## 3. The form is exact per correction segment (Proposition 4)
+
+`Payoffs.PathAccrual.stepAccrual` accounts one price move \(p_i\to p_j\) on a chunk by its overlap segment \([lo,hi]\subseteq[a,b]\): amounts by `getAmount0/1`, fee on the token paid in, LVR = the concavity gap **marked at the corrected price \(p_j\)** (which may lie beyond \(hi\) when the move exits the chunk).
+
+- up (\(p_j\ge hi\)): \(\mathrm{amount}_{in} = \mathrm{amount1} = L(hi-lo)\); \(\mathrm{LVR}_{\mathrm{gross}} = \mathrm{amount0}\cdot p_j^2 - \mathrm{amount1} = L(hi-lo)\big[p_j^2/(lo\,hi) - 1\big]\).
+- down (\(p_j\le lo\)): \(\mathrm{amount}_{in} = \mathrm{amount0}\cdot p_j^2 = L(hi-lo)\,p_j^2/(lo\,hi)\); \(\mathrm{LVR}_{\mathrm{gross}} = \mathrm{amount1} - \mathrm{amount0}\,p_j^2 = L(hi-lo)\big[1 - p_j^2/(lo\,hi)\big]\).
+
+**Proposition 4 (LVR rate per correction segment).** On both token sides,
+\[
+\mathrm{LVR}_{\mathrm{net}} \;=\; \mathrm{amount}_{in}\cdot\Big[\rho - \phi\Big],\qquad
+\rho = \begin{cases} p_j^2/(lo\,hi) - 1 & \text{up}\\[2pt] (lo\,hi)/p_j^2 - 1 & \text{down}\end{cases}
+\]
+and **when the segment ends at the corrected price** (\(p_j = hi\) up, \(p_j = lo\) down — every correction on continuous liquidity, and every correction inside a chunk) \(\rho = r_{1/2}-1\), \(r_{1/2} = hi/lo\): the *sqrt-price return of the correction*. Hence per unit of \(\mathrm{amount}_{in}\) the rate is \(\lambda = r_{1/2}-1-\phi\): zero at \(r_{1/2}-1=\phi\) (a gap of \(2\phi\) ticks — the arb captures half the price gap), linear beyond with slope 1. Token side selects \(\phi_X\) (down) or \(\phi_M\) (up): the \(\lambda_X/\lambda_M\) split of MODEL_CLOSURE §2. Signed: `stepAccrual` clamps the gross at 0 but the net is signed; the claim's \((\cdot)^+\) is the rational-arb restriction (§4), not what the accounting returns.
+
+**Corollary (marginal segments).** A chunk overlapping only the *tail* of a wide correction has \(\rho = p_j^2/(lo\,hi)-1 < \phi\) possible, so a 10-tick leg can lose on a correction that is profitable for the arb overall. A 4-leg position's path rate is therefore a volume-weighted mean of \(\rho-\phi\) over clipped segments — not the pure law — while a chunk covering the path realizes the law exactly.
+
+**Identification (not a derivation).** The anchor writes \(\sigma_{IV} = 2\phi e^{u/2}\), so \(\phi(2e^{u/2}-1) = \sigma_{IV}-\phi\). Prop 4 is that expression *if one defines* \(\sigma_{IV} \equiv r_{1/2}-1\), the realized sqrt-price displacement per correction. This is a relabeling that makes the claim's shape exact; the map from the anchor's transactional \(u\) to the per-correction \(r_{1/2}\) is **open** (rebate note §5 already separates the two "u"s). \(\chi\) enters as claimed — through \(\mathrm{amount}_{in}\), i.e. the three-piece \(\pi^{\Delta Q_X}\) — but it is the segment amount (token1), not \(\chi\) itself; over a full down-range it is \(\chi\cdot p_j^2\) valued in token1.
+
+Regressions (`test/Spec.hs`): step identity up and down, \(g=1..10\) ticks (rel \(10^{-5}\) or 2 wei); clipped-segment form for \(g\in\{1,5,20,60\}\) beyond the chunk; zero crossing at \(g=2\cdot\)band with \(|\mathrm{net}(2\,\mathrm{band})|\) an order below its neighbours. Oracle: these are regressions of the accounting against its own algebra; the independent statement is C3 `lvr_net_step` in the peer file.
+
+## 4. Ex-post check on the composed path
+
+`Payoffs.LvrRate.lvrRateOn`: holder inactive; \(\lambda(s,\phi,\text{band}) = \mathrm{LVR}_{\mathrm{net}}\big/\sum \mathrm{amount}_{in}\) over arb segments (both token1, `stepVolume1`), reported in **pips** so \(\lambda\) and \(\phi\) share an axis; \(s\) = external step per round. Corrections after a round have size \(s\pm\)transAmp, so with the naive band (\(\phi\) in price ticks) all corrections are below \(2\phi\) iff \(s \le 2\phi - 2\,\)transAmp and all above iff \(s\ge 2\phi+\)transAmp — the test windows are derived, not tuned.
+
+Continuous liquidity (one chunk over the path; every correction ends at \(p_j\)), 6 seeds × transAmp \(\{1,2,4\}\) × \(\phi\in\{1000,2000,3000\}\) pips:
+- naive band: \(\lambda\le0\) below the window, \(>0\) above;
+- rational band \(2\phi\) ticks: \(\lambda\ge0\) at every \(s\);
+- transAmp 1: \(\lambda(s) = (s/2-\text{band})\cdot100\) pips \(\pm60\) for all \(s\) above the window — slope 1 in sqrt-return, all seeds and fees (e.g. \(\phi=3000\): \(-998\) at \(s=40\), \(-598\) at 48, \(+4\) at 60).
+
+4-leg position (`planBig`, legs 10 ticks wide): almost no correction lies inside a leg (Model QA probe: 0 of 295–600 fully inside; 27–37 overlapping), so the path rate is the Corollary's clipped mean. It is printed as a seed-5 regression, not asserted: \(\phi=1000\): \(-190, 47, 537, 1069, 1602, 2135\) pips at \(s = 10..60\) — crossing ≈ 19 ticks, slope ≈ 53 pips/tick vs 50; the excess is the \(p_j\)-marking of clipped segments. An earlier draft divided by arb *tick* volume and read the resulting concavity as "out-of-range dilution"; that denominator was the wrong unit and the explanation is withdrawn.
+
+Panel `outputs/Payoffs/Accrual/panel-lvr-rate-vs-step.png`: left, 4-leg naive vs rational bands for \(\phi\in\{1000,2000\}\); right, continuous liquidity at \(\phi=1000\) (crossing at 20, rational \(\ge0\)). Axes: ticks × pips.
+
+## 5. Consequences
+
+- MODEL_CLOSURE §2's design claim is replaced by Prop 4: \(\lambda_{X/M} = (\rho-\phi_{X/M})\) per unit arb volume, \(\rho = r_{1/2}-1\) on unclipped segments. \(\lambda_X,\lambda_M\) are no longer primitives; §3's closure reads \(r^{\varphi} = \phi\delta_{\mathrm{trans}} - [\nu_{\mathrm{arb}}/\nu]\,\mathbb{E}_{\mathrm{arb}}[\rho-\phi]\) with the token-side mixture over up/down corrections.
+- Rational arbitrage: corrections occur iff \(r_{1/2}-1>\phi\), i.e. gaps \(>2\phi\) ticks. `Payoffs.HolderPath.Regime.rgBandTicks` is a price-tick trigger; its rational value is `rationalBandTicks φ = 2·φ/100`. Fact 2's crossing at 40–50 ticks for \(\phi_M=30\) bp is consistent with \(2\phi = 60\) ticks under a naive-band path (the `syntheticPath` steps are not rational corrections); a computed reconciliation is not claimed.
+- Under the rebate (holder active), corrections are Holder-tagged at \(\phi_{\mathrm{eff}}=0\): \(\lambda = \rho\), the whole gap to the holder (Prop B).
+- For Aristotle (C3): \(\lambda\ge0\) iff \(\rho\ge\phi\); nondecreasing in \(r_{1/2}\), nonincreasing in \(\phi\) — algebraic. \(\partial\pi^{\phi}/\partial[\nu_{\mathrm{arb}}/\nu]=0\) is the after-fee *convention* (fees on arb steps are netted inside \(\lambda\)), not a consequence of Prop 4.
+
+## 6. Economic meaning
+
+An arbitrageur's after-fee profit on a correction is the sqrt-price move they capture minus the fee they pay, per unit traded; the LP loses exactly that, segment by segment. Because the arb's fill averages half the price gap, the fee band is \(2\phi\) in price ticks. A concentrated position sees only the segments of corrections that cross its range and can be net-negative on the tail of a wide move even when the arb is rational: concentration converts a pool-level law into a range-weighted one. Implied vol in the anchor's \(2\phi e^{u/2}\) is the same quantity read as a rate — once the transactional \(u\) is mapped to the per-correction displacement, which remains the open link.

--- a/src/Payoffs/LvrRate.hs
+++ b/src/Payoffs/LvrRate.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+-- | λ_{X/M} — per-token LVR rate (README MODEL_CLOSURE §2, issue #51 / TODO #26).
+--
+-- χ(𝓛𝓒) (Prop 3) is EXACT from Theorem 5 and Def 12:
+--   ∫_{a²}^{b²} ∂²π^{ΔQ_X}/∂P² dP = ∂_P π(b²) − ∂_P π(a²) = 0 − amount0(𝓛𝓒),
+-- so the in-range gamma exposure is the chunk's amount0 (raw token0): the total
+-- delta the chunk sheds across its range.  `chi = chunkAmount0`.
+--
+-- Per correction segment [lo, hi] inside a chunk, marked at the corrected price p_j
+-- (Prop 4): LVR_net = amount_in·[p_j²/(lo·hi) − 1 − φ]; when the segment ends at p_j this
+-- is amount_in·[(r½ − 1) − φ], r½ = hi/lo — the arb captures the SQRT-price return, i.e.
+-- half the price gap, so the rational trigger is a gap of 2φ ticks (`rationalBandTicks`).
+-- A chunk covering only the tail of a wide correction earns p_j²/(lo·hi) − 1 < φ on that
+-- segment: a 4-leg position can lose on marginal segments even under the rational band;
+-- a chunk covering the whole path cannot (`lvrRateOn` with a wide chunk).
+--
+-- The rate is measured ex post on the composed path with the holder inactive
+-- (Payoffs.HolderPath): λ(s, φ) = LVR_net / Σ amount_in over arb segments, both token1,
+-- summed over the chunks — the same dimensionless rate as Prop 4, reported in PIPS
+-- (uint24, 1e6 = 1, the FeePips convention, so λ and φ share an axis).
+-- s = external step (ticks / round); band = the arb trigger in ticks (naive φ/100
+-- crosses zero at 2φ; rational 2φ/100 is ≥ 0 on continuous liquidity).
+module Payoffs.LvrRate
+  ( chi
+  , naiveBandTicks
+  , rationalBandTicks
+  , lvrRate
+  , lvrRateOn
+  , lvrRateTable
+  , lvrRateLayout
+  ) where
+
+import Graphics.Rendering.Chart.Easy (Layout)
+
+import Liquidity.LiquidityChunk (LiquidityChunk, chunkAmount0)
+import Panoptic.LegChunk (legChunks)
+import Panoptic.MintPlan (MintPlan)
+import Payoffs.HolderPath (Regime(..), composedPath)
+import Payoffs.PathAccrual (Accrual(..), Step(..), Tag(..), addAccrual, linesLayout, pathAccrual, pattern PIPS_ONE, stepVolume1, zeroAccrual)
+import Pricing.Stremia (FeePips, unFeePips)
+import SqrtGrid (PayoffX96(..), Tick, mulDiv)
+
+-- | χ(𝓛𝓒) = amount0(𝓛𝓒), raw token0.
+chi :: LiquidityChunk -> Integer
+chi ch = let PayoffX96 a = chunkAmount0 ch in a
+
+-- | Price-gap band equal to the fee: φ pips / 100 ticks (1 tick = 1 bp).
+naiveBandTicks :: FeePips -> Int
+naiveBandTicks phi = fromInteger (unFeePips phi `div` 100)
+
+-- | Rational arb trigger from Prop 4: the sqrt-price return must exceed φ ⇒ gap > 2φ ticks.
+rationalBandTicks :: FeePips -> Int
+rationalBandTicks = (2 *) . naiveBandTicks
+
+-- | λ(s; φ, band) on the composed path (seed, i0, n rounds, trans amplitude): pips (signed).
+lvrRate :: Int -> Tick -> Int -> Int -> FeePips -> Int -> MintPlan -> Int -> Integer
+lvrRate seed i0 n transAmp phi band plan = lvrRateOn seed i0 n transAmp phi band (legChunks plan)
+
+-- | Same on an explicit chunk list (a single wide chunk = continuous liquidity over the path).
+lvrRateOn :: Int -> Tick -> Int -> Int -> FeePips -> Int -> [LiquidityChunk] -> Int -> Integer
+lvrRateOn seed i0 n transAmp phi band chs s =
+  let path  = composedPath seed i0 n transAmp s (Regime 1 band False)
+      acc   = foldr addAccrual zeroAccrual [ pathAccrual phi phi ch path | ch <- chs ]
+      nuArb = sum [ stepVolume1 ch st | ch <- chs, st <- path, stepTag st == Arb ]
+      net   = lvrGross acc - feesArb acc
+  in  if nuArb == 0 then 0 else mulDiv net PIPS_ONE nuArb
+
+lvrRateTable :: Int -> Tick -> Int -> Int -> FeePips -> Int -> MintPlan -> [Int] -> [(Integer, Integer)]
+lvrRateTable seed i0 n transAmp phi band plan ss = [ (toInteger s, lvrRate seed i0 n transAmp phi band plan s) | s <- ss ]
+
+-- | λ vs s for several φ, naive band (crosses zero at 2φ ticks) and rational band (≥ 0).
+-- Axes: ticks, pips.
+lvrRateLayout :: Int -> Tick -> Int -> Int -> MintPlan -> [FeePips] -> [Int] -> Layout Double Double
+lvrRateLayout seed i0 n transAmp plan phis ss =
+  linesLayout "λ_{X/M}: LVR_net per unit arb volume vs external step s (holder inactive)"
+    "external step s (ticks / round)" "LVR_net / Σ amount_in (pips)"
+    (concat
+      [ [ ("φ = " ++ show (unFeePips phi) ++ " pips, band φ (naive)", lvrRateTable seed i0 n transAmp phi (naiveBandTicks phi) plan ss)
+        , ("φ = " ++ show (unFeePips phi) ++ " pips, band 2φ (rational)", lvrRateTable seed i0 n transAmp phi (rationalBandTicks phi) plan ss) ]
+      | phi <- phis ])

--- a/src/Payoffs/PathAccrual.hs
+++ b/src/Payoffs/PathAccrual.hs
@@ -24,6 +24,7 @@ module Payoffs.PathAccrual
   , pattern PIPS_ONE
   , syntheticPath
   , stepAccrual
+  , stepVolume1
   , pathAccrual
   , planAccrual
   , netAccrual
@@ -127,6 +128,26 @@ stepAccrual phiX phiM ch (Step iFrom iTo tag)
             Holder -> Accrual 0 fee (max 0 lvr)
   where
     goingUp = iTo > iFrom
+    SqrtPriceX96 a = sqrtPriceX96 (chunkTickLower ch)
+    SqrtPriceX96 b = sqrtPriceX96 (chunkTickUpper ch)
+    SqrtPriceX96 pFrom = sqrtPriceX96 iFrom
+    SqrtPriceX96 pTo = sqrtPriceX96 iTo
+    lo = max a (min pFrom pTo)
+    hi = min b (max pFrom pTo)
+
+-- | Token1 value of the amount paid in over the step's overlap with the chunk
+-- (up: amount1; down: amount0 valued at p_j) — the `amount_in` of Prop 4, so that
+-- LVR_net / Σ stepVolume1 is the dimensionless per-token rate.
+stepVolume1 :: LiquidityChunk -> Step -> Integer
+stepVolume1 ch (Step iFrom iTo _)
+  | iFrom == iTo || hi <= lo = 0
+  | otherwise =
+      let l = chunkLiquidity ch
+          amt0 = mulDiv (l * Q96) (hi - lo) hi `div` lo
+          amt1 = mulDiv l (hi - lo) Q96
+          SqrtPriceX96 pj = sqrtPriceX96 iTo
+      in  if iTo > iFrom then amt1 else mulDiv (mulDiv pj pj Q96) amt0 Q96
+  where
     SqrtPriceX96 a = sqrtPriceX96 (chunkTickLower ch)
     SqrtPriceX96 b = sqrtPriceX96 (chunkTickUpper ch)
     SqrtPriceX96 pFrom = sqrtPriceX96 iFrom

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -217,6 +217,8 @@ import Payoffs.VolatilityReplica (ErrorX96(..), fourLegReplica, legMintValue, re
 import Greeks.Delta (PayoffDelta(..), PriceDeltaX96(..), deltaOfPayoff)
 import Payoffs.ReplicaDelta (replicaDelta)
 import Payoffs.HolderPath (HolderReport(..), Regime(..), arbShare, composedPath, hedgeAlong, holderPnL, pathEndTicks, trianglePath)
+import Payoffs.LvrRate (chi, lvrRateOn, lvrRateTable, naiveBandTicks, rationalBandTicks)
+import Payoffs.ReplicaDelta (principalDelta)
 import Hedge.Ledger (HolderSwap(..), Ledger(..), RebateX96(..), emptyLedger, hedgeStep, ledgerInvariant, payStreamia, qualifying)
 import Panoptic.Binning (binNotionals, binToLegs, ladderFromVolOrder, mintPlanFromLadder, quantizationReport, QuantizationRow(..))
 import qualified Payoffs.PathAccrual as PA
@@ -1318,6 +1320,107 @@ main = do
     else error ("5.5 holder gap " ++ show (maxGap rgOn))
   if maxGap rgOff > maxGap rgOn then putStrLn ("ok: 5.5 stale zone without holder: max correction " ++ show (maxGap rgOff) ++ " vs " ++ show (maxGap rgOn))
     else error ("5.5 gaps: " ++ show (maxGap rgOff, maxGap rgOn))
+
+  -- TODO #26 (#51): λ_{X/M}.  Prop 3: χ(𝓛𝓒) = amount0 = ∂_Pπ(a²) − ∂_Pπ(b²) (Thm 5 + Def 12).
+  let chB = chunks !! 1
+      dAtEdge i = let PriceDeltaX96 d = principalDelta chB (sqrtPriceX96 i) in d
+  assertEqual "Prop 3: χ = amount0 = delta shed across the range"
+    (chi chB) (dAtEdge (chunkTickLower chB) - dAtEdge (chunkTickUpper chB))
+  -- Prop 4 (derived form): one arb correction lo → hi inside the chunk has
+  -- LVR_net = amount_in · [(r½ − 1) − φ], r½ = hi/lo — band-crossing exact, linear in r½ − 1.
+  let
+    phiL   = mkFeePips 1000                                   -- band 10 ticks
+    lo1    = chunkTickLower chB
+    stepOf g = PA.Step lo1 (lo1 + g) PA.Arb
+    netOf g = let PA.Accrual _ fa lg = PA.stepAccrual phiL phiL chB (stepOf g) in lg - fa
+    SqrtPriceX96 sLo = sqrtPriceX96 lo1
+    predicted g = let SqrtPriceX96 sHi = sqrtPriceX96 (lo1 + g)
+                      amt1 = mulDiv (chunkLiquidity chB) (sHi - sLo) Q96
+                  in  mulDiv amt1 (sHi - sLo) sLo - mulDiv amt1 1000 1000000
+  sequence_
+    [ if abs (netOf g - predicted g) <= max 2 (abs (predicted g) `div` 100000) then pure ()
+        else error ("Prop 4 step identity (up) at g = " ++ show g ++ ": " ++ show (netOf g, predicted g))
+    | g <- [1 .. 10] ]
+  -- down side: hi → lo, amount_in = amount0 valued at lo, same bracket.
+  let hi1 = chunkTickUpper chB
+      netDn g = let PA.Accrual _ fa lg = PA.stepAccrual phiL phiL chB (PA.Step hi1 (hi1 - g) PA.Arb) in lg - fa
+      SqrtPriceX96 sHi1 = sqrtPriceX96 hi1
+      predDn g = let SqrtPriceX96 sL = sqrtPriceX96 (hi1 - g)
+                     amt0 = mulDiv (chunkLiquidity chB * Q96) (sHi1 - sL) sHi1 `div` sL
+                     amtIn = mulDiv (mulDiv sL sL Q96) amt0 Q96
+                 in  mulDiv amtIn (sHi1 - sL) sL - mulDiv amtIn 1000 1000000
+  sequence_
+    [ if abs (netDn g - predDn g) <= max 2 (abs (predDn g) `div` 100000) then pure ()
+        else error ("Prop 4 step identity (down) at g = " ++ show g ++ ": " ++ show (netDn g, predDn g))
+    | g <- [1 .. 10] ]
+  putStrLn "ok: Prop 4 step identity, up and down sides"
+  -- Prop 3 independent check: ∫_{a²}^{b²} ∂²π dP = Δ(b⁻) − Δ(a⁺) with deltas from finite
+  -- differences of the PAYOFF (deltaOfPayoff on fromChunk), not from principalDelta.
+  let fdDelta i = let PriceDeltaX96 d = runPayoffDelta (deltaOfPayoff (CLMM.toPayoff (CLMM.fromChunk chB))) (sqrtPriceX96 i) in d
+      integral = fdDelta (chunkTickUpper chB - 1) - fdDelta (chunkTickLower chB + 1)
+  if abs (integral + chi chB) <= chi chB `div` 4   -- one tick in from each edge on a 10-tick chunk: ≤ 20 % + bump
+    then putStrLn "ok: Prop 3 ∫∂²π dP ≈ −χ by finite differences of the payoff"
+    else error ("Prop 3 FD integral: " ++ show (integral, chi chB))
+  -- zero crossing at g = 2·band ticks (sqrt-price return = fee) on a chunk wide enough to
+  -- contain the step: negative at 19, positive at 21, |net(20)| tiny (r½ − 1 = φ up to 1.0001 curvature).
+  let chW = createChunk (-100) 100 (10 ^ (20 :: Int))
+      netW g = let PA.Accrual _ fa lg = PA.stepAccrual phiL phiL chW (PA.Step (-100) (-100 + g) PA.Arb) in lg - fa
+  if netW 19 < 0 && netW 21 > 0 && abs (netW 20) < abs (netW 19) `div` 10
+    then putStrLn "ok: Prop 4 zero crossing at g = 2·band (r½ − 1 = φ)"
+    else error ("Prop 4 crossing: " ++ show (netW 19, netW 20, netW 21))
+  -- Clipped segment (p_j beyond the chunk): LVR_net = amount_in·[p_j²/(lo·hi) − 1 − φ] (up).
+  let hiB = chunkTickUpper chB
+      netClip g = let PA.Accrual _ fa lg = PA.stepAccrual phiL phiL chB (PA.Step lo1 (hiB + g) PA.Arb) in lg - fa
+      SqrtPriceX96 sHiB = sqrtPriceX96 hiB
+      predClip g = let SqrtPriceX96 sPj = sqrtPriceX96 (hiB + g)
+                       amt1 = mulDiv (chunkLiquidity chB) (sHiB - sLo) Q96
+                       ratio = mulDiv (mulDiv sPj sPj Q96) Q96 (mulDiv sLo sHiB Q96)   -- p_j²/(lo·hi), Q96
+                   in  mulDiv amt1 (ratio - Q96) Q96 - mulDiv amt1 1000 1000000
+  sequence_
+    [ if abs (netClip g - predClip g) <= max 4 (abs (predClip g) `div` 10000) then pure ()
+        else error ("Prop 4 clipped segment at g = " ++ show g ++ ": " ++ show (netClip g, predClip g))
+    | g <- [1, 5, 20, 60] ]
+  putStrLn "ok: Prop 4 clipped-segment form (marked at p_j)"
+  -- Path level on CONTINUOUS liquidity (one chunk covering the path, every correction inside):
+  -- seeds × trans amplitudes × fees.  Corrections after a round have size s ± transAmp, so with
+  -- the naive band φ: all steps < 2·band ⇔ s ≤ 2·band − 2·transAmp (λ ≤ 0); smallest step
+  -- ≥ 2·band ⇔ s ≥ 2·band + transAmp (λ > 0).  Rational band 2φ ⇒ λ ≥ 0 everywhere.
+  let chWide = createChunk (-4000) 4000 (10 ^ (20 :: Int))
+      seeds  = [1, 2, 3, 5, 7, 11]
+      amps   = [1, 2, 4]
+      grid   = [2, 4 .. 80]
+  sequence_
+    [ let phiF = mkFeePips phiP
+          band = naiveBandTicks phiF
+          tbl  = [ (sv, lvrRateOn sd 0 600 ta phiF band [chWide] sv) | sv <- grid ]
+          below = [ l | (sv, l) <- tbl, sv <= 2 * band - 2 * ta ]
+          above = [ l | (sv, l) <- tbl, sv >= 2 * band + ta ]
+      in  if all (<= 0) below && all (> 0) above && not (null above) then pure ()
+            else error ("naive band crossing: seed " ++ show sd ++ " amp " ++ show ta ++ " φ " ++ show phiP ++ " " ++ show tbl)
+    | sd <- seeds, ta <- amps, phiP <- [1000, 2000, 3000] ]
+  putStrLn "ok: continuous liquidity + naive band φ ⇒ λ crosses zero in [2φ − 2·transAmp, 2φ + transAmp] ticks (6 seeds × 3 amps × 3 fees)"
+  sequence_
+    [ let phiF = mkFeePips phiP
+          tbl = [ (sv, lvrRateOn sd 0 600 ta phiF (rationalBandTicks phiF) [chWide] sv) | sv <- grid ]
+      in  if all ((>= 0) . snd) tbl then pure () else error ("rational band λ < 0: seed " ++ show sd ++ " amp " ++ show ta ++ " φ " ++ show phiP ++ " " ++ show tbl)
+    | sd <- seeds, ta <- amps, phiP <- [1000, 2000, 3000] ]
+  putStrLn "ok: continuous liquidity + rational band 2φ ⇒ λ ≥ 0 (6 seeds × 3 amps × 3 fees)"
+  -- Slope 1 (Prop 4, linear beyond): with transAmp 1 every correction has size s ± 1, so
+  -- λ(s) ≈ (s/2 − band)·100 pips (1 tick = 100 pips of price = 50 pips of sqrt-return).
+  sequence_
+    [ let phiF = mkFeePips phiP
+          band = naiveBandTicks phiF
+          lamS sv = lvrRateOn sd 0 600 1 phiF band [chWide] sv
+      in  sequence_
+            [ if abs (lamS sv - (50 * toInteger sv - 100 * toInteger band)) <= 60 then pure ()
+                else error ("slope: seed " ++ show sd ++ " φ " ++ show phiP ++ " s " ++ show sv ++ ": " ++ show (lamS sv, 50 * toInteger sv - 100 * toInteger band))
+            | sv <- grid, sv >= 2 * band + 2 ]
+    | sd <- seeds, phiP <- [1000, 2000, 3000] ]
+  putStrLn "ok: continuous liquidity, transAmp 1: λ(s) = (s/2 − band)·100 pips ± 60 (slope 1 in sqrt-return)"
+  -- 4-leg position (legs 10 ticks wide): most corrections are clipped, so the path rate is a
+  -- volume-weighted mean of the clipped form — printed as a regression, not asserted (seed 5).
+  putStrLn ("4-leg λ(s) regression, φ = 1000 naive band, seed 5: "
+    ++ show (lvrRateTable 5 0 600 2 (mkFeePips 1000) (naiveBandTicks (mkFeePips 1000)) planBig [10, 20 .. 60]))
 
   _ <- evaluate (gammaCoordinate (unXiX96 xiPinned) eta spacing10 (-10 :: Tick))
   putStrLn "ok: gammaCoordinate negative tick"


### PR DESCRIPTION
## Summary
- Implements TODO.md #36 (feat; issue #51 / TODO #26): the MODEL_CLOSURE §2 design claim is closed
  - **Prop 3:** χ(𝓛𝓒) = amount0 — ∫_{a²}^{b²} ∂²π dP = ∂_Pπ(b²) − ∂_Pπ(a²) (Thm 5 + `principalDelta`); checked independently by finite differences of the payoff
  - **Prop 4:** per correction segment, LVR_net = amount_in·[ρ − φ], ρ = p_j²/(lo·hi) − 1 (up) / (lo·hi)/p_j² − 1 (down); = r½ − 1 when the segment ends at p_j → zero at 2φ ticks, slope 1. The claimed φ(2e^{u/2}−1)^+ is this under the *identification* σ_IV ≡ r½ − 1 (stated as a relabeling)
  - `Payoffs.LvrRate` (`chi`, `naiveBandTicks`, `rationalBandTicks`, `lvrRate`, `lvrRateOn`, panel); `PathAccrual.stepVolume1` (amount_in per segment so the rate is dimensionless, in pips)
- Spec `docs/superpowers/specs/2026-08-25-scratchpad-lambda-xm-lvr-rate-design.md` after the two-reviewer pass (Reality Checker + Model QA): down side tested, units fixed, tautological Prop 3 test replaced, seed-specific 4-leg assertion replaced by continuous-liquidity tests over 6 seeds × 3 amps × 3 fees with derived windows, clipped-segment form added and tested, "dilution" explanation withdrawn
- README Props 3/4 and MODEL_CLOSURE §2 updated; peer statements C1–C3 in `lean4-spec/scratch/peer-from-scratchpad-chi.md`

## Linked issue
Closes #51

## Test plan
- [x] Prop 4 step identity up and down (g = 1..10), clipped-segment form (g ∈ {1,5,20,60}), crossing at 2·band
- [x] Prop 3 FD integral ≈ −χ
- [x] continuous liquidity: naive-band crossing in [2φ − 2·amp, 2φ + amp]; rational band ⇒ λ ≥ 0; amp 1 ⇒ λ = (s/2 − band)·100 pips ± 60 — 6 seeds × 3 amps × 3 fees
- [x] `stack test --ghc-options=-Werror`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb7TAbixYPnsgNMwXJogp8