### PR TITLE
docs(todo-22): arb weight ∂ = E[share·r_arb]/E[r_arb] (Definition 15); arbShareToken1; statics regressions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -135,6 +135,7 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - Brainstorm: what object is \(\beta\) (scalar weight? pool parameter? function of \(\kappa\)/\(\phi\)/liquidity?); units; bounds; who sets it; relation to measure \(m(\cdot)\) and \(\mathbb E[m\cdot\pi]\)
    - Deliverable: short design note (spec in `docs/superpowers/specs/`) before #21 implement; may stay notes-only if no code twin warranted this cycle
    - Prereq for composing full \(r_{\Delta Q}^{e}\) and unblocking #6
+   - **Answered (2026-08-25):** Definition 15 — \(\partial = \mathbb{E}^{\mathbb{Q}}[\text{share}\cdot r_{\mathrm{arb}}]/\mathbb{E}^{\mathbb{Q}}[r_{\mathrm{arb}}]\) (token1 share `HolderPath.arbShareToken1`; \(\mathbb{E}[\text{share}]\) is the zero-covariance approximation); the share is an output of the update rule; expectation notes-only until #17/#21. `docs/superpowers/specs/2026-08-25-scratchpad-arb-weight-design.md`
 
 23. **\(\nu_{\mathrm{trans}}\) from `volume_path.gms` (prover-native \(u\leftrightarrow\nu\))** — `feat` — [#34](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/34)
    - Spec: `docs/superpowers/specs/2026-08-22-scratchpad-rarb-trans-flow-design.md` §3 (option **B** approved)

--- a/docs/superpowers/specs/2026-08-25-scratchpad-arb-weight-design.md
+++ b/docs/superpowers/specs/2026-08-25-scratchpad-arb-weight-design.md
@@ -1,0 +1,45 @@
+# Scratchpad — the arb-leg weight ∂ in the expected-return split (closes TODO #22 / #28)
+
+**Date:** 2026-08-25  
+**Status:** design note (docs); two-reviewer pass done (Reality Checker, Model QA) — all BLOCKER/MAJOR findings folded in.  
+**Notation anchor:** `VOLATILITY_INSTRUMENTS.md`; README (RARB) split and § MODEL_CLOSURE §3; rebate note (Defs 12–14, Prop B); λ note (Prop 4)
+
+## 1. The question
+
+README (RARB): \(r^{e}_{\Delta Q} = r^{e}_{\Delta Q_{\mathrm{trans}}} + \partial\cdot r^{e}_{\Delta Q_{\mathrm{arb}}}(\sigma_{IV}-\sigma^{e})\), with \(\partial \equiv \partial r^{e}_{\Delta Q}/\partial r^{e}_{\Delta Q_{\mathrm{arb}}}\big|_{r^{e}_{\mathrm{trans}}}\) "a definition by role; its formula is the open item". TODO #22: what object is it, units, bounds, who sets it, relation to the measure. (The symbol \(\beta\) was retired for it by user ruling; it is not the CES \(\beta=\eta\) nor the AdaptiveStremia logistic centres \(\beta_j\).)
+
+**Flag for #21 slice 2.** README uses \(r^{e}_{\Delta Q_{\mathrm{arb}}}\) in two roles: in (RARB) as the arb leg's expected *return*, and in MODEL_CLOSURE §2 / TODO #21 as the token-side *mixture weight* \(\Lambda(\gamma(u-u^\star))\in[0,1]\). This note takes the (RARB) reading — a rate per unit of arb volume, of which Prop 4's \(\lambda\) is the ex-post instance — and leaves the symbol clash to #21.
+
+## 2. Answer
+
+**Ex-post identity.** Per unit of total token1 volume over a chunk list, \(r_{\Delta Q} = r_{\mathrm{trans}} + [\nu_{\mathrm{arb}}/\nu]\cdot r_{\mathrm{arb}}\) holds with \([\nu_{\mathrm{arb}}/\nu]\) the **token1** share \(\sum_{\mathrm{arb}}\mathrm{amount}_{in}/\sum_{\mathrm{all}}\mathrm{amount}_{in}\) (`Payoffs.HolderPath.arbShareToken1`, via `stepVolume1`) and \(r_{\mathrm{arb}}\) per unit arb token1 volume (`Payoffs.LvrRate.lvrRateOn`); both terms then share the denominator \(\nu\). `arbShare` (tick volume) is the liquidity-free proxy and coincides only on continuous liquidity with small ticks. The README's "read, not computed" convention is kept for the identity; the simulator *computes* the reader.
+
+**Definition 15 (arb weight).** Taking \(\mathbb{Q}\)-expectations of the identity at fixed \(r^{e}_{\mathrm{trans}}\),
+\[
+\partial \;:=\; \frac{\mathbb{E}^{\mathbb{Q}}\big[[\nu_{\mathrm{arb}}/\nu]\cdot r_{\mathrm{arb}}\big]}{\mathbb{E}^{\mathbb{Q}}[r_{\mathrm{arb}}]}
+\;=\; \mathbb{E}^{\mathbb{Q}}\big[[\nu_{\mathrm{arb}}/\nu]\big] + \frac{\mathrm{Cov}^{\mathbb{Q}}\big([\nu_{\mathrm{arb}}/\nu],\, r_{\mathrm{arb}}\big)}{\mathbb{E}^{\mathbb{Q}}[r_{\mathrm{arb}}]} .
+\]
+This is exactly the derivative the README defines by role, under linearity of \(r_{\Delta Q}\) in \(r_{\mathrm{arb}}\) (true of the identity). The covariance is not zero — both the share and \(r_{\mathrm{arb}}\) are driven by external vol — so \(\partial = \mathbb{E}^{\mathbb{Q}}[\text{share}]\) is the **zero-covariance approximation**, stated as such. Units: a share in \([0,1]\), pips (`ArbSharePips`, bounded to \([0,10^6]\); no EVM twin yet).
+
+**Who sets it: nobody.** The share is *produced* by the update rule (`composedPath`): per round, trans noise \(\pm\)transAmp moves the pool, the external price moves \(\pm\)extAmp, then the holder corrects if active and \(|e-p|>\)gas, else an arbitrageur corrects if \(|e-p|>\)band, else no one (branch order `HolderPath.hs`, holder first). So \([\nu_{\mathrm{arb}}/\nu]\) is a function of (band, gas, holder flag, external vol, trans-noise amplitude) and the pricing measure enters only through the external process. \(\partial\) is its \(\mathbb{Q}\)-expectation over paths — **not** the rule evaluated at \(\sigma^{e}\): the share is a band-crossing indicator, nonlinear in the path, so \(\mathbb{E}^{\mathbb{Q}}[\text{share}(\text{path})] \ne \text{share}(\text{path at }\mathbb{E}^{\mathbb{Q}}\sigma)\) (Jensen). "Evaluate at \(\sigma^{e}\)" is a further approximation to be checked when \(\sigma^{e}\) (TODO #21 slice 2) exists. The band is an input; its rational value is \(2\phi\) ticks (`rationalBandTicks`, Prop 4) — §5.5 and the panel use band 30 with no fee link.
+
+Code objects: `arbShareToken1` (new, the share of the identity), `arbShare` (proxy). The expectation itself has no code object: `composedPath` is a deterministic LCG path with no measure; \(\partial\) stays notes-only until #17/#21 provide \(\mathbb{Q}\).
+
+**Statics and limits** (holder inactive unless said; regressed in `test/Spec.hs` "Def 15 statics", 4 seeds, on the sampled grids band \(\{0,10,20,40\}\), ext \(\{1,2,4,8\}\)):
+- share \(=0\) iff the holder is active with gas \(\le\) band (holder branch first); gas \(>\) band \(>0\) leaves a positive arb share — both regressed;
+- the **number** of arb corrections is nonincreasing in the band; the **volume** share is *not* monotone in the band (wider band: rarer but larger corrections; Model QA sweep: 284 of 882 adjacent band pairs violate monotonicity; e.g. 240819 pips at band 20 vs 245063 at 40, seed 5);
+- share nondecreasing in external vol on the sampled grid (token1 share on continuous liquidity, tick share); on a unit-step grid single decreases occur (49 of 672 pairs), so the claim is about the \(\mathbb{Q}\)-average, not pathwise;
+- band \(\to0\): every round is corrected; the share tends to \(\mathbb{E}|e'-p'|/(\mathbb{E}|e'-p'|+\text{transAmp})\), \(<1\) whenever trans noise is nonzero (measured 501246…842478 pips for ext 1…16 at trans \(\pm3\)).
+
+## 3. What this does to (RARB) and MODEL_CLOSURE §3
+
+Keep the ex-post bracket and the token-side mixture as written in README § MODEL_CLOSURE §3; the expectation form is the joint one:
+\[
+r^{\varphi} = \phi\,\delta_{\mathrm{trans}} - \big[\tfrac{\nu_{\mathrm{arb}}}{\nu}\big]\big[(1-r^{e}_{\mathrm{arb}})\lambda_X + r^{e}_{\mathrm{arb}}\lambda_M\big],\qquad
+\mathbb{E}^{\mathbb{Q}}[r^{\varphi}] = \phi\,\delta_{\mathrm{trans}} - \mathbb{E}^{\mathbb{Q}}\Big[\big[\tfrac{\nu_{\mathrm{arb}}}{\nu}\big]\cdot\lambda_{\mathrm{mix}}\Big],
+\]
+with \(\lambda_{X/M} = \rho-\phi_{X/M}\) from Prop 4 and \(\phi\delta_{\mathrm{trans}}\) from `Payoffs.TransactionalReturn`, both per unit of total token1 volume. Inputs: \(\phi_{X/M}\), band, gas, holder flag, external vol, trans-noise amplitude. Outputs of the rule: the share, \(\rho\) per correction. Notes-only expectations: \(\mathbb{E}^{\mathbb{Q}}[\cdot]\) and \(\sigma^{e}\) (#21 slice 2). #6 (`ExpectedReturn` composition) is unblocked on the *definition* of the weight and still waits on \(\mathbb{Q}\).
+
+## 4. Economic meaning
+
+The weight of the arbitrage leg in a pool's expected return is neither a preference parameter nor a pool constant: it is how often, and how much, the pool's price is corrected by someone other than its own traders — and who that someone is. Under the rebate the buyer is the corrector whenever gas \(\le\) band, and the arb leg's weight is zero: the instrument has internalized its hedging. Without the rebate the weight is the band-crossing statistic of the external price against the fee, jointly with how much each crossing extracts — a covariance, not a product of averages.

--- a/src/Payoffs/HolderPath.hs
+++ b/src/Payoffs/HolderPath.hs
@@ -19,6 +19,7 @@ module Payoffs.HolderPath
   , composedPath
   , pathEndTicks
   , arbShare
+  , arbShareToken1
   , HolderReport(..)
   , hedgeAlong
   , holderPnL
@@ -28,7 +29,8 @@ module Payoffs.HolderPath
 import Greeks.Delta (PayoffDelta(..), PriceDeltaX96(..))
 import Hedge.Ledger (HolderSwap(..), Ledger(..), RebateX96(..), hedgeStep)
 import Panoptic.MintPlan (MintPlan)
-import Payoffs.PathAccrual (ArbSharePips, Step(..), Tag(..), mkArbSharePips, pattern PIPS_ONE)
+import Liquidity.LiquidityChunk (LiquidityChunk)
+import Payoffs.PathAccrual (ArbSharePips, Step(..), Tag(..), mkArbSharePips, pattern PIPS_ONE, stepVolume1)
 import qualified Payoffs.Payoff as Payoff
 import Payoffs.ReplicaDelta (replicaDelta)
 import Payoffs.VolatilityReplica (fourLegReplica)
@@ -71,6 +73,15 @@ pathEndTicks = map stepTo
 arbShare :: [Step] -> ArbSharePips
 arbShare steps =
   let vol tag = sum [ toInteger (abs (stepTo s - stepFrom s)) | s <- steps, stepTag s == tag ]
+      total = vol Trans + vol Arb + vol Holder
+  in  mkArbSharePips (if total == 0 then 0 else mulDiv (vol Arb) PIPS_ONE total)
+
+-- | [ν_arb/ν] in TOKEN1 volume over a chunk list (Σ stepVolume1 of arb steps / Σ of all
+-- steps) — the share that weights a per-unit-volume rate (Prop 4's λ) in (RARB).
+-- `arbShare` (tick volume) is the liquidity-free proxy; this one is the accounting share.
+arbShareToken1 :: [LiquidityChunk] -> [Step] -> ArbSharePips
+arbShareToken1 chs steps =
+  let vol tag = sum [ stepVolume1 ch st | ch <- chs, st <- steps, stepTag st == tag ]
       total = vol Trans + vol Arb + vol Holder
   in  mkArbSharePips (if total == 0 then 0 else mulDiv (vol Arb) PIPS_ONE total)
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -216,7 +216,7 @@ import Panoptic.LegChunk (legChunk, legChunks, legLiquidity)
 import Payoffs.VolatilityReplica (ErrorX96(..), fourLegReplica, legMintValue, replicaError, windowTicks)
 import Greeks.Delta (PayoffDelta(..), PriceDeltaX96(..), deltaOfPayoff)
 import Payoffs.ReplicaDelta (replicaDelta)
-import Payoffs.HolderPath (HolderReport(..), Regime(..), arbShare, composedPath, hedgeAlong, holderPnL, pathEndTicks, trianglePath)
+import Payoffs.HolderPath (HolderReport(..), Regime(..), arbShare, arbShareToken1, composedPath, hedgeAlong, holderPnL, pathEndTicks, trianglePath)
 import Payoffs.LvrRate (chi, lvrRateOn, lvrRateTable, naiveBandTicks, rationalBandTicks)
 import Payoffs.ReplicaDelta (principalDelta)
 import Payoffs.TransactionalReturn (TransTurnover(..), measuredFeeReturn, refTransactionalReturn, transTurnover)
@@ -1322,6 +1322,38 @@ main = do
     else error ("5.5 holder gap " ++ show (maxGap rgOn))
   if maxGap rgOff > maxGap rgOn then putStrLn ("ok: 5.5 stale zone without holder: max correction " ++ show (maxGap rgOff) ++ " vs " ++ show (maxGap rgOn))
     else error ("5.5 gaps: " ++ show (maxGap rgOff, maxGap rgOn))
+  -- TODO #22 (#28), Definition 15 statics (holder inactive): the share is nondecreasing in
+  -- external vol (token1 share on continuous liquidity and tick share); in the band, what
+  -- falls is the NUMBER of corrections — a wider band makes corrections rarer but larger, so
+  -- the volume share need not be monotone (seen: 240819 at band 20 vs 245063 at 40, seed 5).
+  let chCont = createChunk (-4000) 4000 (10 ^ (20 :: Int))
+      pathOf sd band ext = composedPath sd 0 400 2 ext (Regime 1 band False)
+      shareT sd band ext = PA.unArbSharePips (arbShareToken1 [chCont] (pathOf sd band ext))
+      shareK sd band ext = PA.unArbSharePips (arbShare (pathOf sd band ext))
+      nArb sd band ext   = length [ () | st <- pathOf sd band ext, PA.stepTag st == PA.Arb ]
+      monoDown xs = and (zipWith (>=) xs (drop 1 xs))
+      monoUp xs   = and (zipWith (<=) xs (drop 1 xs))
+      bands = [0, 10, 20, 40]
+      exts  = [1, 2, 4, 8]
+  sequence_
+    [ if monoUp [ f sd 10 e | e <- exts ] then pure ()
+        else error ("share ↑ vol fails: seed " ++ show sd ++ " " ++ lbl ++ " " ++ show [ f sd 10 e | e <- exts ])
+    | sd <- [1, 3, 5, 7], (lbl, f) <- [("token1", shareT), ("tick", shareK)] ]
+  sequence_
+    [ if monoDown [ nArb sd b 4 | b <- bands ] then pure ()
+        else error ("#corrections ↓ band fails: seed " ++ show sd ++ " " ++ show [ nArb sd b 4 | b <- bands ])
+    | sd <- [1, 3, 5, 7] ]
+  putStrLn "ok: Def 15 statics: share ↑ in external vol (token1 on continuous liquidity, tick); #corrections ↓ in band (4 seeds)"
+  sequence_
+    [ if PA.unArbSharePips (arbShare (composedPath sd 0 400 2 4 (Regime 1 b True))) == 0 then pure ()
+        else error ("holder active but arb share > 0: seed " ++ show sd ++ " band " ++ show b)
+    | sd <- [1, 3, 5, 7], b <- [2, 10, 40] ]
+  putStrLn "ok: Def 15: holder active with gas 1 ⇒ share = 0 for every band ≥ 2 (4 seeds)"
+  sequence_
+    [ if PA.unArbSharePips (arbShare (composedPath sd 0 400 2 4 (Regime 5 2 True))) > 0 then pure ()
+        else error ("gas > band > 0 should leave arb share > 0: seed " ++ show sd)
+    | sd <- [1, 3, 5, 7] ]
+  putStrLn "ok: Def 15: holder active with gas 5 > band 2 ⇒ arb share > 0 (branch order)"
 
   -- TODO #26 (#51): λ_{X/M}.  Prop 3: χ(𝓛𝓒) = amount0 = ∂_Pπ(a²) − ∂_Pπ(b²) (Thm 5 + Def 12).
   let chB = chunks !! 1


### PR DESCRIPTION
## Summary
- TODO.md #22 (docs): design note `docs/superpowers/specs/2026-08-25-scratchpad-arb-weight-design.md` — ∂ is the ex-ante arb share weight, exact form E^Q[share·r_arb]/E^Q[r_arb] (E[share] = zero-covariance approximation; "evaluate at σ^e" flagged as Jensen approximation); share is an output of the update rule; token1 share `Payoffs.HolderPath.arbShareToken1` added so the weight matches Prop 4's per-unit-volume rate
- Statics regressed (4 seeds): share = 0 iff holder active with gas ≤ band (and > 0 for gas > band > 0), #corrections ↓ in band (volume share NOT monotone — documented), share ↑ in external vol on the sampled grid; band→0 limit stated correctly
- Two-reviewer pass (Reality Checker + Model QA); all BLOCKER/MAJOR addressed; README symbol clash r^e_arb (rate vs Λ mixture weight) flagged for #31

## Linked issue
Closes #28

## Test plan
- [x] Def 15 statics + branch-order regressions; `stack test --ghc-options=-Werror`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb7TAbixYPnsgNMwXJogp8