### PR TITLE
chore(todo-37): rename to cfmm-vol-markets-spec, package metadata, tick TODO #37

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,10 @@
 
 ---
 
+37. ~~**Bring the Lean work into this repo and disassociate from `cfmm-replicationPlank`; name it — repo renamed `cfmm-vol-markets-spec`**~~ — `feat` — [#97](https://github.com/JMSBPP/cfmm-vol-markets-spec/issues/97) / [#98](https://github.com/JMSBPP/cfmm-vol-markets-spec/pull/98) ✓ merged (merge commit, history preserved) — `docs/superpowers/specs/2026-08-26-lean-migration-design.md`
+   - `lean/{vol_markets,exp,tao}`, `notes/VOLATILITY_INSTRUMENTS.md`, `model/{exp,vol_markets,tao}` imported with history; Lake files at root; CI `lake build` is a required check (7 min on ubuntu-latest)
+   - open follow-ups: Plank-side deletion of the moved paths + archive `JMSBPP/cfmm-lean4-spec`; dangling links `../refs/DemeterfietalVarianceSwaps.pdf`, `./tbd.md`, `./pos_spec.md`; Haskell package still `cfmm-scratchpad`
+
 ## Open
 
 **Role roadmap (read first):** `docs/superpowers/specs/2026-08-22-scratchpad-channel-roles-roadmap.md`  
@@ -193,14 +197,6 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
 36. **λ_{X/M} derived (Prop 4) + χ = amount0 (Prop 3) — `Payoffs.LvrRate`, ex-post panel, spec; closes the MODEL_CLOSURE §2 design claim (TODO #26 / #51)** — `feat` — [#51](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/51) / [#94](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/94) ✓ merged
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
-
-### Lean spec migration
-
-37. **Bring the Lean work into this repo and disassociate from `cfmm-replicationPlank`; name it — repo becomes `cfmm-vol-markets-spec` (taxonomy: spec reference for protocols building vol-instruments on top of CFMMs)** — `feat` — `docs/superpowers/specs/2026-08-26-lean-migration-design.md`
-   - import `lean/{vol_markets,exp,tao}`, `notes/VOLATILITY_INSTRUMENTS.md`, `model/{exp,vol_markets,tao}` with history (filter-repo + merge commit); Lake files at root, `srcDir = "lean"`
-   - CI job `lake build` (sorry/admit guard) → second required check on `main`
-   - re-anchor citations to repo-relative paths; README **Role** section
-   - follow-ups: `chore/` rename PR; Plank-side deletion + archive `cfmm-lean4-spec`; dangling links `../refs/DemeterfietalVarianceSwaps.pdf`, `./tbd.md`, `./pos_spec.md`; Haskell package still `cfmm-scratchpad`
 
 ### Package / tree moves (README `//` notes; not done)
 

--- a/cfmm-scratchpad.cabal
+++ b/cfmm-scratchpad.cabal
@@ -6,12 +6,12 @@ cabal-version: 2.2
 
 name:           cfmm-scratchpad
 version:        0.1.0.0
-description:    Please see the README on GitHub at <https://github.com/githubuser/cfmm-scratchpad#readme>
-homepage:       https://github.com/githubuser/cfmm-scratchpad#readme
-bug-reports:    https://github.com/githubuser/cfmm-scratchpad/issues
-author:         Author name here
-maintainer:     example@example.com
-copyright:      2026 Author name here
+description:    Haskell twin of cfmm-vol-markets-spec (spec reference for vol-instruments on CFMMs). See <https://github.com/JMSBPP/cfmm-vol-markets-spec#readme>
+homepage:       https://github.com/JMSBPP/cfmm-vol-markets-spec#readme
+bug-reports:    https://github.com/JMSBPP/cfmm-vol-markets-spec/issues
+author:         JMSBPP
+maintainer:     juan.serranotmf@gmail.com
+copyright:      2026 JMSBPP
 license:        BSD-3-Clause
 license-file:   LICENSE
 build-type:     Simple
@@ -21,7 +21,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/githubuser/cfmm-scratchpad
+  location: https://github.com/JMSBPP/cfmm-vol-markets-spec
 
 library
   exposed-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -1,10 +1,10 @@
 name:                cfmm-scratchpad
 version:             0.1.0.0
-github:              "githubuser/cfmm-scratchpad"
+github:              "JMSBPP/cfmm-vol-markets-spec"
 license:             BSD-3-Clause
-author:              "Author name here"
-maintainer:          "example@example.com"
-copyright:           "2026 Author name here"
+author:              "JMSBPP"
+maintainer:          "juan.serranotmf@gmail.com"
+copyright:           "2026 JMSBPP"
 
 extra-source-files:
 - README.md
@@ -17,7 +17,7 @@ extra-source-files:
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
 # common to point users to the README.md file.
-description:         Please see the README on GitHub at <https://github.com/githubuser/cfmm-scratchpad#readme>
+description:         Haskell twin of cfmm-vol-markets-spec (spec reference for vol-instruments on CFMMs). See <https://github.com/JMSBPP/cfmm-vol-markets-spec#readme>
 
 dependencies:
 - base >= 4.7 && < 5


### PR DESCRIPTION
## Summary
- Tracks TODO.md #37 close-out (`chore`): GitHub repo renamed `cfmm-volInstrumentsFormal` → `cfmm-vol-markets-spec` (old URLs redirect); `package.yaml` metadata points at the new repo (hpack regenerated `cfmm-scratchpad.cabal`; Haskell package name unchanged); TODO #37 moved under **Done** with follow-ups listed.

## Linked issue
Refs #97 (closed by #98)

## Test plan
- [x] `stack build --pedantic` locally
- [ ] CI: `stack build && stack test` + `lake build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTEBW3vLxCzSMZF1rH6BJL