### PR TITLE
chore(ci): concurrency cancel-in-progress + least-privilege token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main]
 
+# A force-push cancels the superseded run (the lake build alone is ~7 min); least-privilege token.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   stack:
     name: stack build && stack test


### PR DESCRIPTION
## Summary
- CI hygiene ported from `cfmm-replicationPlank`'s `develop-gate.yml` (the only parts of that workflow applicable here besides the already-ported `lean` job): `concurrency` with `cancel-in-progress` (a force-push cancels the superseded ~7-min `lake build`) and `permissions: contents: read`.
- No job changes. Follow-up of TODO #37 (#97).

## Test plan
- [ ] CI: `stack build && stack test` + `lake build` green with the read-only token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTEBW3vLxCzSMZF1rH6BJL