### PR TITLE
docs: repoint dead cfmm-lean4-spec mirror citations

### DIFF
--- a/notes/agents/vol_markets/ARISTOTLE_SUMMARY.md
+++ b/notes/agents/vol_markets/ARISTOTLE_SUMMARY.md
@@ -142,7 +142,7 @@ untouched).
 - Docstring caveats recorded: traded-volume reading of `dp`; no demand
   elasticity in this functional (volume trade-off = FeeSchedule layer).
 
-# Summary of changes for run 128b24ae (task 311f81e5) — issue cfmm-lean4-spec#1
+# Summary of changes for run 128b24ae (task 311f81e5) — former mirror issue cfmm-lean4-spec#1 (repo deleted 2026-08-26; see LEAN_TRACEABILITY.md §8)
 Aristotle formalized the staged doc block `## VOL ORDER COMPLETION —
 ENDOGENOUS MATURITY` (VolOrder v2 delegation) into
 `vol_markets/EndogenousMaturity.lean` (331 lines, 8 defs + 34 theorems,

--- a/notes/agents/vol_markets/LEAN_TRACEABILITY.md
+++ b/notes/agents/vol_markets/LEAN_TRACEABILITY.md
@@ -5,7 +5,7 @@
 Its claim-by-claim map is §7. The supporting reference documents are the
 markdowns in this directory. This file maps
 every claim in them to the machine-checked Lean layer
-(`lean/vol_markets/*.lean`, mirrored at `JMSBPP/cfmm-lean4-spec`), and fixes
+(`lean/vol_markets/*.lean` in this repo; the former `JMSBPP/cfmm-lean4-spec` mirror was deleted 2026-08-26), and fixes
 the shared notation. Statuses: **PROVEN** (sorry-free, axiom-clean:
 `propext`/`Classical.choice`/`Quot.sound` only), **CORRECTED** (doc claim was
 wrong; the true statement is proven), **REFUTED** (counterexample proven),
@@ -334,7 +334,9 @@ failure and none may be quietly dropped when this layer is cited downstream.
 | 8 | **`η⋆` is σ-INDEXED; η is a design constant** | The fee entering `etaStar` is a fixed scalar, whereas this document's fee is `multiFee(σ)` and `φ̄` is only its FLOOR. The Phase-11 corner therefore induces `η⋆(σ)` pointwise while the grid exponent is chosen once at pool creation. Reconciling the two is not addressed — and a beforeSwap/afterSwap hook cannot vary η | **OPEN** |
 | 9 | **The strict single-peakedness boundary** | Under `cOne ≤ 0` the LP payoff is flat in `κ_φ` and `etaStar` is not an argmax at all (`liquidity_freeze_minimal`, `lpPayoff_isMaxOn` are stated under `0 < cOne`); the sign of `c₁` at the fee corner is pinned by nothing in this layer | **OPEN** |
 
-## 8. `VOL ORDER COMPLETION — ENDOGENOUS MATURITY` (doc block, issue cfmm-lean4-spec#1 → `EndogenousMaturity.lean`)
+## 8. `VOL ORDER COMPLETION — ENDOGENOUS MATURITY` (doc block → `lean/vol_markets/EndogenousMaturity.lean`)
+
+> Provenance: formalized from the former mirror's issue `cfmm-lean4-spec#1` (VolOrder v2 delegation, 2026-07-30). That repo was deleted on 2026-08-26 and the issue is unreachable; the doc block was never merged into the anchor, so what survives of it is the claim table below (every claim ↔ theorem), the Aristotle run summary in `ARISTOTLE_SUMMARY.md` (run 128b24ae, task 311f81e5), and the module docstring of `EndogenousMaturity.lean`.
 
 Notation: `ΔQ_v★` → `dQvStar`; `t★` → `tStar`; `N_σ` → `Nσ`; `ΔM_req` → `dMReq`.
 

--- a/notes/agents/vol_markets/VOLATILITY_INSTRUMENTS_LEAN_ADDENDUM.md
+++ b/notes/agents/vol_markets/VOLATILITY_INSTRUMENTS_LEAN_ADDENDUM.md
@@ -4,8 +4,8 @@
 > `../cfmm-wt/plank/notes/VOLATILITY_INSTRUMENTS.md` per user approval
 > (todo.md `## LEAN4 - MATH`); block H left as an in-doc FLAG pending the
 > author's sign decision. Committing the plank file is the plank agent's.
-> Every block cites the machine-checked lemma (`lean/vol_markets/*`, mirrored at
-> `JMSBPP/cfmm-lean4-spec`). Minimal prose; each block is insert-ready LaTeX.
+> Every block cites the machine-checked lemma (`lean/vol_markets/*` in this repo;
+> the former `JMSBPP/cfmm-lean4-spec` mirror was deleted 2026-08-26). Minimal prose; each block is insert-ready LaTeX.
 
 ## A. [CORRECTION] Amount nonnegativity — insert after the `ΔQ_M^L, ΔQ_X^L` display
 


### PR DESCRIPTION
## Summary
- The old Lean mirror `JMSBPP/cfmm-lean4-spec` is deleted; its issue #1 (ENDOGENOUS MATURITY delegation) is unreachable. `LEAN_TRACEABILITY.md` §8, `ARISTOTLE_SUMMARY.md` and `VOLATILITY_INSTRUMENTS_LEAN_ADDENDUM.md` now point at `lean/vol_markets/EndogenousMaturity.lean` with a provenance note (the doc block was never merged into the anchor; the §8 claim table + run summary + module docstring are what survive).

## Linked issue
Closes #105

## Test plan
- [ ] CI green (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTEBW3vLxCzSMZF1rH6BJL