### PR TITLE
docs: repoint repo links to canonical d2p-finance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,15 +12,15 @@
 
 4. ~~`ExpectedReturn` + \(\pi^{\Delta Q}(r^e)\) mixture~~ — `ReturnFromKappa` (FeeStructure / FeePips); `runSwapAlongTenorMixture`
 
-5. ~~**Parametrized fee capture** \(\pi^\phi(r_\phi^e)\)~~ — `feat` — [#1](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/1) / [#14](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/14)
+5. ~~**Parametrized fee capture** \(\pi^\phi(r_\phi^e)\)~~ — `feat` — [#1](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/1) / [#14](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/14)
    - `feeRevenueExpectedReturn` (\(r_\phi^e=\phi\cdot r^e\)); `runFeeCaptureAlongTenorMixture`
 
-6. ~~**`MarkUpStructure` superclass; `FeeStructure` as instance**~~ — `feat` — [#4](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/4) / [#17](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/17)
+6. ~~**`MarkUpStructure` superclass; `FeeStructure` as instance**~~ — `feat` — [#4](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/4) / [#17](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/17)
    - `Pricing.MarkUpStructure` + `TwoSidedMarkUp`; Swap / `ReturnFromKappa` / capture migrate to polymorphic markup; survival `toFeePips` unchanged
 
 ---
 
-37. ~~**Bring the Lean work into this repo and disassociate from `cfmm-replicationPlank`; name it — repo renamed `cfmm-vol-markets-spec`**~~ — `feat` — [#97](https://github.com/JMSBPP/cfmm-vol-markets-spec/issues/97) / [#98](https://github.com/JMSBPP/cfmm-vol-markets-spec/pull/98) ✓ merged (merge commit, history preserved) — `docs/superpowers/specs/2026-08-26-lean-migration-design.md`
+37. ~~**Bring the Lean work into this repo and disassociate from `cfmm-replicationPlank`; name it — repo renamed `cfmm-vol-markets-spec`**~~ — `feat` — [#97](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/97) / [#98](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/98) ✓ merged (merge commit, history preserved) — `docs/superpowers/specs/2026-08-26-lean-migration-design.md`
    - `lean/{vol_markets,exp,tao}`, `notes/VOLATILITY_INSTRUMENTS.md`, `notes/agents/{exp,vol_markets,tao}` imported with history; Lake files at root; CI `lake build` is a required check (7 min on ubuntu-latest)
    - open follow-ups: Plank-side deletion of the moved paths + archive `JMSBPP/cfmm-lean4-spec`; dangling links `../refs/DemeterfietalVarianceSwaps.pdf`, `./tbd.md`, `./pos_spec.md`; Haskell package still `cfmm-scratchpad`
 
@@ -48,41 +48,41 @@ Workflow: see `AGENTS.md` / `CLAUDE.md` / `QWEN.md` (classify → branch → iss
 
 | TODO | Type | Issue | PR | Status |
 |------|------|-------|-----|--------|
-| 6 | `feat` | [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2) | [#15](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/15) | **blocked** (prereqs 17–21) |
-| 7 | `feat` | [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3) | [#16](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/16) | ✓ `Payoffs.TransactionalReturn` — r^φ = φ_X δ_X + φ_M δ_M exact (2026-08-25) |
-| 9 | `feat` | [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) | [#18](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/18) | ✓ Algebra `AdaptiveFee.sol` port (2026-08-25) |
-| 10 | `refactor` | [#6](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/6) | [#19](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/19) | open |
-| 11 | `refactor` | [#7](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/7) | [#20](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/20) | open |
-| 12 | `refactor` | [#8](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/8) | [#21](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/21) | open |
-| 13 | `refactor` | [#9](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9) | [#22](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/22) | open |
-| 14 | `feat` | [#10](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/10) | [#23](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/23) | open |
-| 15 | `docs` | [#11](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/11) | [#24](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/24) | open |
-| 16 | `chore` | [#12](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/12) | [#13](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/13) | open |
+| 6 | `feat` | [#2](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/2) | [#15](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/15) | **blocked** (prereqs 17–21) |
+| 7 | `feat` | [#3](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/3) | [#16](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/16) | ✓ `Payoffs.TransactionalReturn` — r^φ = φ_X δ_X + φ_M δ_M exact (2026-08-25) |
+| 9 | `feat` | [#5](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/5) | [#18](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/18) | ✓ Algebra `AdaptiveFee.sol` port (2026-08-25) |
+| 10 | `refactor` | [#6](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/6) | [#19](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/19) | open |
+| 11 | `refactor` | [#7](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/7) | [#20](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/20) | open |
+| 12 | `refactor` | [#8](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/8) | [#21](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/21) | open |
+| 13 | `refactor` | [#9](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/9) | [#22](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/22) | open |
+| 14 | `feat` | [#10](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/10) | [#23](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/23) | open |
+| 15 | `docs` | [#11](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/11) | [#24](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/24) | open |
+| 16 | `chore` | [#12](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/12) | [#13](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/13) | open |
 | 17 | `feat` | — | — | open (no GitHub issue yet) |
 | 18 | `feat` | — | — | open (no GitHub issue yet) |
 | 19 | `feat` | — | — | open (no GitHub issue yet) |
 | 20 | `feat` | — | — | open (no GitHub issue yet) |
-| 21 | `docs`→`feat` | [#31](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/31) | [#33](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/33) | open — **Slice 1 merged**; Slice 2+ remain |
-| 22 | `docs` | [#28](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/28) | — | open |
-| 23 | `feat` | [#34](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/34) | [#92](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/92) | ✓ closed — re-scoped by #31/#32; arb half = residual of the holder rule (TODO #35); trans half = GAMS replay |
-| 24 | `docs`→`feat` | [#35](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/35) | — | open |
-| 25 | `docs`→`feat` | [#36](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/36) | — | open |
+| 21 | `docs`→`feat` | [#31](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/31) | [#33](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/33) | open — **Slice 1 merged**; Slice 2+ remain |
+| 22 | `docs` | [#28](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/28) | — | open |
+| 23 | `feat` | [#34](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/34) | [#92](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/92) | ✓ closed — re-scoped by #31/#32; arb half = residual of the holder rule (TODO #35); trans half = GAMS replay |
+| 24 | `docs`→`feat` | [#35](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/35) | — | open |
+| 25 | `docs`→`feat` | [#36](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/36) | — | open |
 
 ### Pricing / returns / fee-revenue
 
-6. **`ExpectedReturn` composition / nonzero \(r(0)\)** — `feat` — [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2) / [#15](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/15) — **BLOCKED / deferred**
+6. **`ExpectedReturn` composition / nonzero \(r(0)\)** — `feat` — [#2](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/2) / [#15](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/15) — **BLOCKED / deferred**
    - Parked until measure / expectation / return-split prereqs (**#17–#21**) exist
    - Then: `ExpectedReturn <>` Realized (and other expecteds) → that sum *is* future \(r(0)\) before κ-scaling
    - FeePips path today is through-origin (\(r=\kappa\phi\)); VISIBLE NOTE in `Pricing.ExpectedReturn`
    - Do **not** implement #6 while brainstorming #17–#21
 
-7. **Ref transactional return** \(r^\phi=\phi\,\delta_{\mathrm{trans}}\) — `feat` — [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3)
+7. **Ref transactional return** \(r^\phi=\phi\,\delta_{\mathrm{trans}}\) — `feat` — [#3](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/3)
    - Distinct from payoff \(\pi^\phi\); scope in `refs/VOLATILITY_INTRUMENTS_MEV.md`
    - Decide: scalar control return type vs leave in notes only
    - **Notation:** keep scratchpad \(r^\phi\) / \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) language; do **not** adopt MEV-doc \(\Delta\pi_{\mathrm{trans}}/\pi_{\mathrm{trans}}\) labels (wrong)
    - **Done (PR #16, 2026-08-25):** `Payoffs.TransactionalReturn` — `transTurnover` (δ_X, δ_M in pips of the position's token1 notional), `refTransactionalReturn` = φ_X δ_X + φ_M δ_M, `measuredFeeReturn` = fees_trans/N; equal within 2 pips on composed and round-trip paths (decision: typed `ReturnPips`, not notes-only)
 
-9. **`AdaptiveStremia` body** — `feat` — [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) / [#18](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/18) — **done 2026-08-25:** integer-exact port of Algebra `AdaptiveFee.sol` (user ruling: that IS the functional form); Θ_φ = the 7-field config, ν argument dropped (V1-only); `pathVolatility` in oracle units
+9. **`AdaptiveStremia` body** — `feat` — [#5](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/5) / [#18](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/18) — **done 2026-08-25:** integer-exact port of Algebra `AdaptiveFee.sol` (user ruling: that IS the functional form); Θ_φ = the 7-field config, ν argument dropped (V1-only); `pathVolatility` in oracle units
 
 Yes, those issues matches the intention, but the numbered order that is as it is right now does not imply the hierarchy of importance and the hierarchy of importance is now defined as follows. We are choosing to implement the issues as they have less like semantic impact. For example, renames are less semantically impactful because for example, the fee structure to mark up structure is just refactoring code. And then we start like imposing an order of execution of the issues based on that
 ### Measure / expectation / \(r_{\Delta Q}^{e}\) split (README affine story; prereqs for #6)
@@ -125,7 +125,7 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - Module `Volatility.ImpliedVolatility` (T0); T1 observer / T2 u88 deferred
    - No GitHub issue yet (open when plan approved)
 
-21. **Parametric \(r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{IV},\sigma^{e})\)** — `docs` then `feat` — [#31](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/31) / [#33](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/33)
+21. **Parametric \(r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{IV},\sigma^{e})\)** — `docs` then `feat` — [#31](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/31) / [#33](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/33)
    - \(\sigma^{e}\) = risk-neutral expectation of realized vol (`ExpectedVolatility` + `VolHorizon`: WINDOW \| tenor); spec `docs/superpowers/specs/2026-08-22-scratchpad-expected-volatility-design.md`
    - **Slice 1 merged (PR #33):** `ExpectedVolatility` uniform tenor + window stub, minimal `ImpliedVolatility`, `volGap`
    - Remaining: Slice 2+; arb gap \(g(\cdot)\); full \(\mathbb{E}^{\mathbb{Q}}\) via #17–#18
@@ -133,7 +133,7 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - `feat`: `ImpliedVolatility`/`ExpectedVolatility` → \(u^{\star}\) → `volGap` → \(\Lambda\) (reuse `AdaptiveStremia` sigmoid); orthogonality lemma to Aristotle alongside #35
    - Depends on #20; **#22** (\(\beta\)) before compose
 
-22. **Understand \(\beta\) in the \(r_{\Delta Q}^{e}\) affine split** — `docs` — [#28](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/28)
+22. **Understand \(\beta\) in the \(r_{\Delta Q}^{e}\) affine split** — `docs` — [#28](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/28)
    - Canonical split (README): \(r_{\Delta Q}^{e}=r_{\Delta Q_{\mathrm{trans}}}^{e}+\beta\cdot r_{\Delta Q_{\mathrm{arb}}}^{e}(\sigma_{IV},\sigma^{e})\)
    - **Disambiguate** \(\beta\) from other repo uses: CES \(\beta=\eta\) (CPMM elasticity), AdaptiveStremia/MEV \(\beta_j\) (logistic centers) — not the same symbol economically
    - Brainstorm: what object is \(\beta\) (scalar weight? pool parameter? function of \(\kappa\)/\(\phi\)/liquidity?); units; bounds; who sets it; relation to measure \(m(\cdot)\) and \(\mathbb E[m\cdot\pi]\)
@@ -141,7 +141,7 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - Prereq for composing full \(r_{\Delta Q}^{e}\) and unblocking #6
    - **Answered (2026-08-25):** Definition 15 — \(\partial = \mathbb{E}^{\mathbb{Q}}[\text{share}\cdot r_{\mathrm{arb}}]/\mathbb{E}^{\mathbb{Q}}[r_{\mathrm{arb}}]\) (token1 share `HolderPath.arbShareToken1`; \(\mathbb{E}[\text{share}]\) is the zero-covariance approximation); the share is an output of the update rule; expectation notes-only until #17/#21. `docs/superpowers/specs/2026-08-25-scratchpad-arb-weight-design.md`
 
-23. **\(\nu_{\mathrm{trans}}\) from `volume_path.gms` (prover-native \(u\leftrightarrow\nu\))** — `feat` — [#34](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/34)
+23. **\(\nu_{\mathrm{trans}}\) from `volume_path.gms` (prover-native \(u\leftrightarrow\nu\))** — `feat` — [#34](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/34)
    - Spec: `docs/superpowers/specs/2026-08-22-scratchpad-rarb-trans-flow-design.md` §3 (option **B** approved)
    - Shock: \(V=\bar L e^u\), \(\delta^\*\) → `volTgtWad`, `txlVolumeRate`; \(u=\ln(V/\bar L)=\ln\kappa\) at prover boundary
    - Derive \(\nu_{\mathrm{trans}}=\sum\sqrt{\bar p|\Delta Q_X\Delta Q_M|}\) from JSON `dQx`/`dQM`; \(\big[\nu_{\mathrm{trans}}/\nu\big]\) read as an atomic given value (not a computed ratio)
@@ -149,14 +149,14 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - Prereq for #7 \(\delta_{\mathrm{trans}}=\nu_{\mathrm{trans}}/\pi_{\mathrm{trans}}^{\Delta Q}\) beyond stub; complements RARB Slice 1 Lane B (#19 `TransactionalReturn`)
    - Reads: `refs/volume_path.gms`, `refs/VOLUME_PATH.md`, `refs/MEV_TAX_MODEL_ONE_NOTES.md`
 
-24. **\(\pi^{\varphi}=\pi^{\phi}-\pi^{\mathrm{LVR}}\) decomposition** — `docs`→`feat` — [#35](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/35)
+24. **\(\pi^{\varphi}=\pi^{\phi}-\pi^{\mathrm{LVR}}\) decomposition** — `docs`→`feat` — [#35](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/35)
    - Spec: `docs/superpowers/specs/2026-08-22-scratchpad-pi-varphi-lvr-decomposition-design.md`
    - \(\pi^{c|p}+\pi^{\mathrm{RAN}}\equiv\pi^{\varphi}\) (CLMM); \(\pi^{\varphi}=\pi^{\phi}(\pi_{\mathrm{trans}}^{\Delta Q})-\pi^{\mathrm{LVR}}(\pi_{\mathrm{arb}}^{\Delta Q})\)
    - \(\pi^{\mathrm{arb}}\equiv\pi_{\mathrm{arb}}^{\Delta Q}\) (#21); LVR = normalized return read off arb leg; \(r^{\varphi}=r^{\phi}-r^{\mathrm{LVR}}\)
    - Depends: RARB trans tag (#19), arb mixture (#21); CLMM identity test vs `CLMMPosition`
    - **CLMM identity PROVED (2026-08-23):** \(\pi^{\varphi}(\mathrm{Id}_i[\mathcal{LC}];p)=\mathrm{amount}_0(\mathrm{Id}_i)\,[\pi^{c|p}+\pi^{\mathrm{RAN}}](p)\), \(r\) = sqrt-price ratio; normalization per \((i,\Delta_i)\) not per \(\Delta_i\). `CLMMPosition.fromChunk` (chunk-constructed, #27) + witness test. Remaining: \(\chi(\mathcal{LC})\) definition for #26; Aristotle transcription
 
-25. **\(\pi^{\sigma}=f(\pi^{\varphi})\) — Panoptic/Haskell bridge (not MEV Σ)** — ~~`docs`~~→`feat` — [#36](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/36) / docs half merged [#38](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/38) (2026-08-23)
+25. **\(\pi^{\sigma}=f(\pi^{\varphi})\) — Panoptic/Haskell bridge (not MEV Σ)** — ~~`docs`~~→`feat` — [#36](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/36) / docs half merged [#38](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/38) (2026-08-23)
    - **Ground truth:** shipped Hop A/B — \(\pi^{\sigma}=\Delta Q_{v}\cdot\Pi^{\sigma}_{\mathrm{opt}}\) with
      \(\Pi^{\sigma}_{\mathrm{opt}}=N_{\mathrm{id}}\bigl((P-P^{\star})/P^{\star}-\ln(P/P^{\star})\bigr)+R\) (`VariancePortfolio` / `MintPlan` → `targetVegaFromMint`)
    - ~~**Open:** identify how \(\pi^{\varphi}\) enters \(\Pi_{\mathrm{opt}}\) / \(R\) / the book~~ **Pinned (README, #38):** \(\hat\pi^{\sigma}\equiv\sum_{k=0}^{3}[\pi^{\varphi}(\ell_k;p^\star)-\pi^{\varphi}(\ell_k;p)]\), \(\ell_k=(i_k^-,i_k^+,L_k)\), \(L_k=\Lambda(i_k^-,i_k^+;\mathrm{or}(k)\Delta Q_\upsilon)\); \(\pi^{\varphi}(\ell;p_{1/2})\) = Uniswap V3 position value. Hop A/B \(F-\mathrm{Log}\) = continuum-limit remark; MEV \(\sum L(i)\pi^{\varphi}(i)\) = short side, **not** ground truth
@@ -165,55 +165,55 @@ r_{\Delta Q_{\mathrm{trans}}}^{e}
    - Depends: #24 (net \(\pi^{\varphi}\)); uses existing `VariancePortfolio` / `CLMMPosition`
    - Deliverable: ~~design note pinning \(f\) from Haskell~~ (#38); then code/tests (a)–(d)
 
-26. **\(\lambda_{X/M}\) per-token LVR rate claim** — `docs`→`feat` — [#51](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/51)
+26. **\(\lambda_{X/M}\) per-token LVR rate claim** — `docs`→`feat` — [#51](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/51)
    - README `MODEL_CLOSURE` §2: \(\lambda_{X/M}(u,\phi_{X/M};\mathcal{LC}_{\mathrm{leg}})\overset{?}{=}\phi_{X/M}(2e^{u/2}-1)^+\chi(\mathcal{LC}_{\mathrm{leg}})\); LVR = arb after-fee profit
    - Spec (define \(\chi\), derive/refute) → ex-post check (benchmark − `principal` along `TickPath`) → Aristotle statement with #35
    - Depends: #35, #36 feat, #34 (+19/20); proof gated on parent `.planning` Phase 3
 
-27. **Fold `ChunkPrincipal` into `CLMMPosition` as a `Scale`** — `refactor` — [#54](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/54)
+27. **Fold `ChunkPrincipal` into `CLMMPosition` as a `Scale`** — `refactor` — [#54](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/54)
    - `chunkPrincipal` = \(\mathrm{amount}_0(\mathcal{LC})\cdot\) `CLMMPosition` (per-tick identity, #35) ⇒ `fromChunk`, `Scale = Unit | ByAmount0`, plot flag; amounts → `LiquidityChunk`; delete `Payoffs.ChunkPrincipal`
    - Precedes #36 (four \(\mathcal{LC}_{\mathrm{leg}}\) built on `fromChunk`)
 
-28. **T1/T2 ladder replication of `VariancePortfolio` (Panoptic × LDF hybrid)** — `docs`→`fix`/`feat` — [#59](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/59)
+28. **T1/T2 ladder replication of `VariancePortfolio` (Panoptic × LDF hybrid)** — `docs`→`fix`/`feat` — [#59](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/59)
    - Spec: `docs/superpowers/specs/2026-08-24-scratchpad-ladder-replication-design.md` (v3; Reality Checker + Solidity SC Engineer ×2)
    - T0 continuum → T1 geometric ladder \(\ell(\xi^\star,\iota;x)\) (fixed benchmark, Bunni-realizable) → T2 4-leg via \(\mathcal{B}\) on token1 notional (`asset = 1` all legs); knobs \(\theta_{\mathrm{LDF}}=(\xi_P,\xi_C,\omega)\); norm B, C later
-   - Sub-issues: **0 ✓** [#61](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/61)/PR #62 (asset = 1 all legs, integerSqrt strike, mulDiv staged forms, `docs/BITWIDTHS.md`); **1 ✓** [#63](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/63)/PR #64 (`lnQ96`); **2 ✓** `Payoffs.LadderPosition` (T1; regressions of Thm 7(i)/9/10, Prop 1; T1/N_1 vs c(4000)·logPortfolio 2.8e-6); **3 ✓** `Panoptic.Binning` + `replicaError` (Cor 1/Thm 8 regressions; \(e^\sigma_W(\mathcal B)=2.1\)e-4 at S=4000, \(\approx S^2\) sweep; or = (127,…) = equal notional per leg, Cor 4); **4 ✓** README § REPLICATION_THEORY — **#28 complete** except the peer follow-ons (O(Δi) bound, off-midpoint strike, χ via Thm 5)
+   - Sub-issues: **0 ✓** [#61](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/61)/PR #62 (asset = 1 all legs, integerSqrt strike, mulDiv staged forms, `docs/BITWIDTHS.md`); **1 ✓** [#63](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/63)/PR #64 (`lnQ96`); **2 ✓** `Payoffs.LadderPosition` (T1; regressions of Thm 7(i)/9/10, Prop 1; T1/N_1 vs c(4000)·logPortfolio 2.8e-6); **3 ✓** `Panoptic.Binning` + `replicaError` (Cor 1/Thm 8 regressions; \(e^\sigma_W(\mathcal B)=2.1\)e-4 at S=4000, \(\approx S^2\) sweep; or = (127,…) = equal notional per leg, Cor 4); **4 ✓** README § REPLICATION_THEORY — **#28 complete** except the peer follow-ons (O(Δi) bound, off-midpoint strike, χ via Thm 5)
    - Supersedes TODO #25 (c) (Hop B comparison) via Item 1
 
-29. **Single T0 definition; `VariancePortfolio` = reference only** — `refactor` — [#77](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/77)
+29. **Single T0 definition; `VariancePortfolio` = reference only** — `refactor` — [#77](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/77)
    - `logPortfolioQ96` moves to `Payoffs.Log`; `VariancePortfolio.fromDef6` = \(N_{\mathrm{id}}\cdot\)`logPortfolioQ96` + R, `fromLegs` delegates; module labelled T0 reference; `panel-replica-vs-hopB` retired (superseded by t1-vs-t0 / t2-vs-t1)
 
-30. **Path accrual — fees and LVR per chunk along a tagged tick path; comparative statics** — `feat` — [#79](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/79)
+30. **Path accrual — fees and LVR per chunk along a tagged tick path; comparative statics** — `feat` — [#79](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/79)
    - `Payoffs.PathAccrual`: per-step amounts moved (Uniswap), fee on the token paid in, LVR on arb steps = concavity gap (Thm 5); split fees_trans/fees_arb/LVR_gross; LVR_net = LVR_gross − fees_arb; \(\pi^{\varphi}\) = fees_trans − LVR_net
    - Synthetic tagged path (LCG + Bresenham share); 4-leg roll-up; panels vs \([\nu_{\mathrm{arb}}/\nu]\) and vs step size; prover path replaces it in #34
 
-31. **Price-update transfer \(s\) replaces \(\tau_{\mathrm{MEV}}\); arbs as delta-hedgers; #34 re-scoped** — `docs` — [#82](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/82)
-32. **Delta-hedge rebate: holder-hedged replication supersedes the signed transfer \(s\) (Defs 12–14, Prop B); #34 re-scoped into trans / holder-hedge / residual-arb** — `docs` — [#84](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/84) / [#85](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/85) — `docs/superpowers/specs/2026-08-25-scratchpad-delta-hedge-rebate-design.md`
+31. **Price-update transfer \(s\) replaces \(\tau_{\mathrm{MEV}}\); arbs as delta-hedgers; #34 re-scoped** — `docs` — [#82](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/82)
+32. **Delta-hedge rebate: holder-hedged replication supersedes the signed transfer \(s\) (Defs 12–14, Prop B); #34 re-scoped into trans / holder-hedge / residual-arb** — `docs` — [#84](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/84) / [#85](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/85) — `docs/superpowers/specs/2026-08-25-scratchpad-delta-hedge-rebate-design.md`
    - Note: `docs/superpowers/specs/2026-08-25-scratchpad-price-update-transfer-design.md` — Prop A (roles), Defs 9–11 (signed \(s\), budget, equilibrium \(\mathrm{LVR}_{\mathrm{net}}=s^\star\nu_{\mathrm{arb}}\)), two-source path (GAMS round trips + external update rule)
    - #34 becomes: trans half = GAMS replay (given \([\nu_{\mathrm{trans}}/\nu]\), \(u\)); arb half = \(P_{\mathrm{ext}}\) + rule at \(s\) (\([\nu_{\mathrm{arb}}/\nu]\) as output). Implementation item next.
-33. **ReplicaDelta — \(\hat\Delta^\sigma=\partial_P\hat\pi^\sigma\) as a `Greeks.Delta` instance on the 4-leg replica (Def 12; rebate-note test §5.1)** — `feat` — [#86](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/86) / [#87](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/87) ✓ merged
-34. **Hedge.Ledger — (h, B_s, B_r), `hedgeStep` (Defs 13–14; rebate-note test §5.2)** — `feat` — [#89](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/89) / [#90](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/90) ✓ merged
-35. **HolderPath — composed path (trans / holder / residual arb), `hedgeAlong` (Prop B), \([\nu_{\mathrm{arb}}/\nu]\) as output; rebate-note tests §5.3–5.5; re-scoped #34 (TODO #23) closed** — `feat` — [#91](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/91) / [#92](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/92) ✓ merged
-36. **λ_{X/M} derived (Prop 4) + χ = amount0 (Prop 3) — `Payoffs.LvrRate`, ex-post panel, spec; closes the MODEL_CLOSURE §2 design claim (TODO #26 / #51)** — `feat` — [#51](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/51) / [#94](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/94) ✓ merged
+33. **ReplicaDelta — \(\hat\Delta^\sigma=\partial_P\hat\pi^\sigma\) as a `Greeks.Delta` instance on the 4-leg replica (Def 12; rebate-note test §5.1)** — `feat` — [#86](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/86) / [#87](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/87) ✓ merged
+34. **Hedge.Ledger — (h, B_s, B_r), `hedgeStep` (Defs 13–14; rebate-note test §5.2)** — `feat` — [#89](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/89) / [#90](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/90) ✓ merged
+35. **HolderPath — composed path (trans / holder / residual arb), `hedgeAlong` (Prop B), \([\nu_{\mathrm{arb}}/\nu]\) as output; rebate-note tests §5.3–5.5; re-scoped #34 (TODO #23) closed** — `feat` — [#91](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/91) / [#92](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/92) ✓ merged
+36. **λ_{X/M} derived (Prop 4) + χ = amount0 (Prop 3) — `Payoffs.LvrRate`, ex-post panel, spec; closes the MODEL_CLOSURE §2 design claim (TODO #26 / #51)** — `feat` — [#51](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/51) / [#94](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/94) ✓ merged
 
 Later (not opened yet): compose \(r_{\Delta Q}^{e}\) from #19+#21; wire into parametrized \(\pi^{\Delta Q}/\pi^{\phi}\); then unblock #6.
 
 ### Package / tree moves (README `//` notes; not done)
 
-10. **`Panoptic/` package** — `refactor` — [#6](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/6) — move `NId.hs`, `MintPlan.hs` out of `Payoffs/`
+10. **`Panoptic/` package** — `refactor` — [#6](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/6) — move `NId.hs`, `MintPlan.hs` out of `Payoffs/`
 
-11. **`Plotting/` package** — `refactor` — [#7](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/7) — move `PlotSqrt.hs`, `PlotInterest.hs`, `PlotUtils.hs`
+11. **`Plotting/` package** — `refactor` — [#7](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/7) — move `PlotSqrt.hs`, `PlotInterest.hs`, `PlotUtils.hs`
 
-12. **Rename** `CPMMPosition` → `CLMMPosition` — `refactor` — [#8](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/8)
+12. **Rename** `CPMMPosition` → `CLMMPosition` — `refactor` — [#8](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/8)
 
-13. **`TargetVega`** — `refactor` — [#9](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/9) — move out of `Payoffs/`
+13. **`TargetVega`** — `refactor` — [#9](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/9) — move out of `Payoffs/`
 
 ### Liquidity / density (pre-existing)
 
-14. **Chunk × density EVM mul** — `feat` — [#10](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/10)
+14. **Chunk × density EVM mul** — `feat` — [#10](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/10)
 
-15. **Density → Panoptic `optionRatio` brainstorm** — `docs` — [#11](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/11)
+15. **Density → Panoptic `optionRatio` brainstorm** — `docs` — [#11](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/11)
 
 ### Hygiene
 
-16. **Commit / PR** scratchpad WIP — `chore` — [#12](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/12)
+16. **Commit / PR** scratchpad WIP — `chore` — [#12](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/12)

--- a/cfmm-scratchpad.cabal
+++ b/cfmm-scratchpad.cabal
@@ -6,9 +6,9 @@ cabal-version: 2.2
 
 name:           cfmm-scratchpad
 version:        0.1.0.0
-description:    Haskell twin of cfmm-vol-markets-spec (spec reference for vol-instruments on CFMMs). See <https://github.com/JMSBPP/cfmm-vol-markets-spec#readme>
-homepage:       https://github.com/JMSBPP/cfmm-vol-markets-spec#readme
-bug-reports:    https://github.com/JMSBPP/cfmm-vol-markets-spec/issues
+description:    Haskell twin of cfmm-vol-markets-spec (spec reference for vol-instruments on CFMMs). See <https://github.com/d2p-finance/cfmm-vol-markets-spec#readme>
+homepage:       https://github.com/d2p-finance/cfmm-vol-markets-spec#readme
+bug-reports:    https://github.com/d2p-finance/cfmm-vol-markets-spec/issues
 author:         JMSBPP
 maintainer:     juan.serranotmf@gmail.com
 copyright:      2026 JMSBPP
@@ -21,7 +21,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/JMSBPP/cfmm-vol-markets-spec
+  location: https://github.com/d2p-finance/cfmm-vol-markets-spec
 
 library
   exposed-modules:

--- a/docs/superpowers/plans/2026-08-22-scratchpad-expected-volatility.md
+++ b/docs/superpowers/plans/2026-08-22-scratchpad-expected-volatility.md
@@ -13,7 +13,7 @@
 ## Global Constraints
 
 - Working directory: `/home/jmsbpp/learning/cfmm-theory/scratchpad`
-- Branch: `feat/todo-21-expected-volatility-slice1` (issue [#31](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/31))
+- Branch: `feat/todo-21-expected-volatility-slice1` (issue [#31](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/31))
 - σ^e and σ_X use **same integer units** as `VolatilityAverage` — not FeePips, not u88 sqrt trick
 - `OracleWindowHorizon` Slice 1 = **identity stub** from realized average (documented non-𝔼^Q placeholder)
 - `TenorHorizon` Slice 1 = **uniform** path — `averageVolatility` on `InterestPriceMap` tick ladder

--- a/docs/superpowers/specs/2026-08-22-scratchpad-channel-roles-roadmap.md
+++ b/docs/superpowers/specs/2026-08-22-scratchpad-channel-roles-roadmap.md
@@ -28,10 +28,10 @@
 
 | TODO | Issue | Role in lane A |
 |------|-------|----------------|
-| #23 | [#34](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/34) | Prover-native \(\nu_{\mathrm{trans}}\) / \(g\) from GAMS JSON |
+| #23 | [#34](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/34) | Prover-native \(\nu_{\mathrm{trans}}\) / \(g\) from GAMS JSON |
 | #19 | — | Exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\) → \(\pi_{\mathrm{trans}}^{\Delta Q}\) |
-| #7 | [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3) | \(r^{\phi}=\phi\,\delta_{\mathrm{trans}}\) (return, not \(\pi^{\phi}\)) |
-| #9 | [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) | \(\phi(\Theta;\sigma^2,\nu)\) — fee schedule **consumes** \(\nu\), not \(\Delta Q\) |
+| #7 | [#3](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/3) | \(r^{\phi}=\phi\,\delta_{\mathrm{trans}}\) (return, not \(\pi^{\phi}\)) |
+| #9 | [#5](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/5) | \(\phi(\Theta;\sigma^2,\nu)\) — fee schedule **consumes** \(\nu\), not \(\Delta Q\) |
 
 Specs: `2026-08-22-scratchpad-rarb-trans-flow-design.md`; `refs/volume_path.gms`, `VOLUME_PATH.md`.
 
@@ -52,8 +52,8 @@ Specs: `2026-08-22-scratchpad-rarb-trans-flow-design.md`; `refs/volume_path.gms`
 | TODO | Issue | Role in lane B |
 |------|-------|----------------|
 | #20 | — | Latent \(u=\ln(V/L)\); \(\sigma_{\mathrm{IV}}=2\phi e^{u/2}\) |
-| #21 | [#31](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/31) | \(\sigma^{e}\), `volGap`, \(r_{\mathrm{arb}}^{e}\), \(\pi_{\mathrm{arb}}^{\Delta Q}\) |
-| #22 | [#28](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/28) | Weight \(\beta\) on arb leg in RARB return split |
+| #21 | [#31](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/31) | \(\sigma^{e}\), `volGap`, \(r_{\mathrm{arb}}^{e}\), \(\pi_{\mathrm{arb}}^{\Delta Q}\) |
+| #22 | [#28](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/28) | Weight \(\beta\) on arb leg in RARB return split |
 
 Specs: `2026-08-22-scratchpad-sigma-iv-latent-u-design.md`; `2026-08-22-scratchpad-expected-volatility-design.md`.
 
@@ -79,9 +79,9 @@ So the position payoff is a **function of net fee revenue** = transactional fee 
 
 | TODO | Issue | Role in lane C |
 |------|-------|----------------|
-| #24 | [#35](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/35) | \(\pi^{\varphi}\) decomposition; LVR functional; CLMM identity |
+| #24 | [#35](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/35) | \(\pi^{\varphi}\) decomposition; LVR functional; CLMM identity |
 | #17–#18 | — | Measure \(m\), \(\mathbb{E}^{\mathbb{Q}}[m\cdot\pi^{\varphi}]\) |
-| #6 | [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2) | Compose returns → \(r(0)\); **blocked** until A+B returns exist |
+| #6 | [#2](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/2) | Compose returns → \(r(0)\); **blocked** until A+B returns exist |
 
 Spec: `2026-08-22-scratchpad-pi-varphi-lvr-decomposition-design.md`.
 
@@ -114,14 +114,14 @@ Refactor / hygiene can interleave anytime (low semantic impact): **#10–#13, #1
 
 | Wave | Goal | TODOs | Start when |
 |------|------|-------|------------|
-| **0** | Merge in-flight σ^e Slice 1 + docs | PR [#33](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/33) / #21 Slice 1 | now |
-| **1 — Trans controls** | Parametrize \(\pi_{\mathrm{trans}}^{\Delta Q}\); GAMS stays path prover | **#19** (open issue), then **#7** stub [#3](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/3) | after Wave 0 |
-| **2 — Prover bridge** | Transients → \(\nu_{\mathrm{trans}}\), \(g\); pin \(\delta_{\mathrm{trans}}\) | **#23** [#34](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/34) | after #19 |
-| **3 — Vol / arb controls** | \(\sigma_{IV}\), \(\sigma^{e}\), gap → \(r_{\mathrm{arb}}^{e}\), \(\pi_{\mathrm{arb}}^{\Delta Q}\) | **#20**, **#21** feat, **#22** [#28](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/28) | after Wave 1 (can overlap Wave 2) |
-| **4 — Net \(\pi^{\varphi}\)** | Fee − LVR; CLMM check | **#24** [#35](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/35) | after #19 + #21 arb leg enough |
+| **0** | Merge in-flight σ^e Slice 1 + docs | PR [#33](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/33) / #21 Slice 1 | now |
+| **1 — Trans controls** | Parametrize \(\pi_{\mathrm{trans}}^{\Delta Q}\); GAMS stays path prover | **#19** (open issue), then **#7** stub [#3](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/3) | after Wave 0 |
+| **2 — Prover bridge** | Transients → \(\nu_{\mathrm{trans}}\), \(g\); pin \(\delta_{\mathrm{trans}}\) | **#23** [#34](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/34) | after #19 |
+| **3 — Vol / arb controls** | \(\sigma_{IV}\), \(\sigma^{e}\), gap → \(r_{\mathrm{arb}}^{e}\), \(\pi_{\mathrm{arb}}^{\Delta Q}\) | **#20**, **#21** feat, **#22** [#28](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/28) | after Wave 1 (can overlap Wave 2) |
+| **4 — Net \(\pi^{\varphi}\)** | Fee − LVR; CLMM check | **#24** [#35](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/35) | after #19 + #21 arb leg enough |
 | **5 — \(\pi^{\sigma}=f(\pi^{\varphi})\)** | Pin Panoptic \(f\) linking \(\Pi_{\mathrm{opt}}\) to \(\pi^{\varphi}\) | **#25** | after #24 |
-| **6 — Measure + compose** | \(\mathbb{E}^{\mathbb{Q}}\); unblock #6 | **#17**, **#18**, **#6** [#2](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/2) | after Waves 3–4 |
-| **Parallel** | Adaptive fee body consuming \(\nu\) | **#9** [#5](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/issues/5) | after #23 enough for \(\nu\) |
+| **6 — Measure + compose** | \(\mathbb{E}^{\mathbb{Q}}\); unblock #6 | **#17**, **#18**, **#6** [#2](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/2) | after Waves 3–4 |
+| **Parallel** | Adaptive fee body consuming \(\nu\) | **#9** [#5](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/5) | after #23 enough for \(\nu\) |
 | **Side** | Liquidity / Panoptic density | **#14**, **#15** | anytime |
 
 **First code issue to open and execute:** TODO **#19** (exogenous \(r_{\Delta Q_{\mathrm{trans}}}^{e}\)).
@@ -136,7 +136,7 @@ Refactor / hygiene can interleave anytime (low semantic impact): **#10–#13, #1
 | \(\pi^{\Delta Q}(r^e)\) mixture | Done |
 | `CLMMPosition` = call\|put + RAN | Done |
 | `MarkUpStructure` | Done |
-| \(\sigma^{e}\) Slice 1 stub | **Merged** PR [#33](https://github.com/JMSBPP/cfmm-volInstrumentsFormal/pull/33) |
+| \(\sigma^{e}\) Slice 1 stub | **Merged** PR [#33](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/33) |
 | `volume_path.gms` prover | In `refs/` — **path utility**, not Haskell payoff |
 
 ---

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 name:                cfmm-scratchpad
 version:             0.1.0.0
-github:              "JMSBPP/cfmm-vol-markets-spec"
+github:              "d2p-finance/cfmm-vol-markets-spec"
 license:             BSD-3-Clause
 author:              "JMSBPP"
 maintainer:          "juan.serranotmf@gmail.com"
@@ -17,7 +17,7 @@ extra-source-files:
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
 # common to point users to the README.md file.
-description:         Haskell twin of cfmm-vol-markets-spec (spec reference for vol-instruments on CFMMs). See <https://github.com/JMSBPP/cfmm-vol-markets-spec#readme>
+description:         Haskell twin of cfmm-vol-markets-spec (spec reference for vol-instruments on CFMMs). See <https://github.com/d2p-finance/cfmm-vol-markets-spec#readme>
 
 dependencies:
 - base >= 4.7 && < 5


### PR DESCRIPTION
## Summary
- After the org transfer (canonical `d2p-finance/cfmm-vol-markets-spec`, `JMSBPP/...` = fork) 91 links in TODO.md, specs/plans and package metadata pointed at the JMSBPP names, where issues/PRs do not exist. All rewritten to d2p-finance.

## Linked issue
Closes #110

## Test plan
- [ ] CI green (docs/metadata only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTEBW3vLxCzSMZF1rH6BJL