### PR TITLE
docs: Fork → PR workflow (d2p-finance canonical, JMSBPP fork)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Assign a conventional type from the item’s nature:
 
 ```bash
 git checkout main
-git pull
+git pull upstream main          # canonical = d2p-finance/cfmm-vol-markets-spec; origin = JMSBPP fork
 git checkout -b <type>/todo-<N>-<short-slug>
 ```
 
@@ -31,7 +31,7 @@ Examples: `feat/todo-5-param-fee-capture`, `refactor/todo-10-panoptic-package`.
 Write the TODO item body into the issue (title + full open-item text). Label or title-prefix with the type, e.g. `[feat] TODO #5: …`.
 
 ```bash
-gh issue create --title "[<type>] TODO #<N>: <short title>" --body "$(cat <<'EOF'
+gh issue create --repo d2p-finance/cfmm-vol-markets-spec --title "[<type>] TODO #<N>: <short title>" --body "$(cat <<'EOF'
 ## TODO.md item #<N>
 
 <paste open item>
@@ -43,7 +43,9 @@ EOF
 )"
 ```
 
-## 4. Open a PR (branch → `main`)
+## 4. Open a PR (fork branch → canonical `main`)
+
+Never push to `d2p-finance/*` directly: push the branch to the `JMSBPP` fork (`origin`) and open the PR against the canonical repo (`upstream`).
 
 Commit work (or a tracking stub if implementation is not started). Push and open PR targeting `main`.
 
@@ -61,8 +63,8 @@ Solves #<ISSUE_NUMBER>
 ```
 
 ```bash
-git push -u origin HEAD
-gh pr create --base main --title "<type>(todo-<N>): <short title>" --body "…"
+git push -u origin HEAD            # to the JMSBPP fork
+gh pr create --repo d2p-finance/cfmm-vol-markets-spec --base main --head JMSBPP:$(git branch --show-current) --title "<type>(todo-<N>): <short title>" --body "…"
 ```
 
 ## 5. Cross-comments (required)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Assign a conventional type from the item’s nature:
 
 ```bash
 git checkout main
-git pull
+git pull upstream main          # canonical = d2p-finance/cfmm-vol-markets-spec; origin = JMSBPP fork
 git checkout -b <type>/todo-<N>-<short-slug>
 ```
 
@@ -31,7 +31,7 @@ Examples: `feat/todo-5-param-fee-capture`, `refactor/todo-10-panoptic-package`.
 Write the TODO item body into the issue (title + full open-item text). Label or title-prefix with the type, e.g. `[feat] TODO #5: …`.
 
 ```bash
-gh issue create --title "[<type>] TODO #<N>: <short title>" --body "$(cat <<'EOF'
+gh issue create --repo d2p-finance/cfmm-vol-markets-spec --title "[<type>] TODO #<N>: <short title>" --body "$(cat <<'EOF'
 ## TODO.md item #<N>
 
 <paste open item>
@@ -43,7 +43,9 @@ EOF
 )"
 ```
 
-## 4. Open a PR (branch → `main`)
+## 4. Open a PR (fork branch → canonical `main`)
+
+Never push to `d2p-finance/*` directly: push the branch to the `JMSBPP` fork (`origin`) and open the PR against the canonical repo (`upstream`).
 
 Commit work (or a tracking stub if implementation is not started). Push and open PR targeting `main`.
 
@@ -61,8 +63,8 @@ Solves #<ISSUE_NUMBER>
 ```
 
 ```bash
-git push -u origin HEAD
-gh pr create --base main --title "<type>(todo-<N>): <short title>" --body "…"
+git push -u origin HEAD            # to the JMSBPP fork
+gh pr create --repo d2p-finance/cfmm-vol-markets-spec --base main --head JMSBPP:$(git branch --show-current) --title "<type>(todo-<N>): <short title>" --body "…"
 ```
 
 ## 5. Cross-comments (required)

--- a/QWEN.md
+++ b/QWEN.md
@@ -20,7 +20,7 @@ Assign a conventional type from the item’s nature:
 
 ```bash
 git checkout main
-git pull
+git pull upstream main          # canonical = d2p-finance/cfmm-vol-markets-spec; origin = JMSBPP fork
 git checkout -b <type>/todo-<N>-<short-slug>
 ```
 
@@ -31,7 +31,7 @@ Examples: `feat/todo-5-param-fee-capture`, `refactor/todo-10-panoptic-package`.
 Write the TODO item body into the issue (title + full open-item text). Label or title-prefix with the type, e.g. `[feat] TODO #5: …`.
 
 ```bash
-gh issue create --title "[<type>] TODO #<N>: <short title>" --body "$(cat <<'EOF'
+gh issue create --repo d2p-finance/cfmm-vol-markets-spec --title "[<type>] TODO #<N>: <short title>" --body "$(cat <<'EOF'
 ## TODO.md item #<N>
 
 <paste open item>
@@ -43,7 +43,9 @@ EOF
 )"
 ```
 
-## 4. Open a PR (branch → `main`)
+## 4. Open a PR (fork branch → canonical `main`)
+
+Never push to `d2p-finance/*` directly: push the branch to the `JMSBPP` fork (`origin`) and open the PR against the canonical repo (`upstream`).
 
 Commit work (or a tracking stub if implementation is not started). Push and open PR targeting `main`.
 
@@ -61,8 +63,8 @@ Solves #<ISSUE_NUMBER>
 ```
 
 ```bash
-git push -u origin HEAD
-gh pr create --base main --title "<type>(todo-<N>): <short title>" --body "…"
+git push -u origin HEAD            # to the JMSBPP fork
+gh pr create --repo d2p-finance/cfmm-vol-markets-spec --base main --head JMSBPP:$(git branch --show-current) --title "<type>(todo-<N>): <short title>" --body "…"
 ```
 
 ## 5. Cross-comments (required)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 
 Rule: the twin cites theorem names (`LadderPrincipal.principal_inRange`, `GeomMixture.xiStar_argmin`, `ClmmIdentity.principal_price_second_deriv`, …) and never re-proves. Before introducing a symbol, grep the anchor — bare `κ` is taken; `κ_φ` is the curvature coordinate.
 
+## Contributing / Workflow
+
+**Fork → PR workflow (d2p-finance canonical):** the `d2p-finance` org owns the CANONICAL/upstream repos; the `JMSBPP/*` repos are the develop FORKS. ALL changes are made on the JMSBPP/* forks and reach the d2p-finance/* canonical repos ONLY through pull requests (fork → upstream). Never commit or push directly to a d2p-finance canonical repo — open a PR from the JMSBPP fork.
+
+For this repo: `origin` = `JMSBPP/cfmm-vol-markets-spec` (fork), `upstream` = `d2p-finance/cfmm-vol-markets-spec` (canonical). Branch from `upstream/main`, push to `origin`, open the PR against `d2p-finance:main`; `main` there requires the `stack build && stack test` and `lake build` checks. Issues live on the canonical repo.
+
 # PRICE_GRID
 
 Fee-deformed sqrt-price quotes; the chunk bounds are identified with them: \(p_{1/2}^{(\mathrm{bid})} \equiv p_{1/2}^{(\mathrm{bid})}\), \(p_{1/2}^{(\mathrm{ask})} \equiv p_{1/2}^{(\mathrm{ask})}\), and bid/ask notation is used throughout.


### PR DESCRIPTION
## Summary
- README gains **Contributing / Workflow**: the owner's ecosystem-wide rule — d2p-finance = canonical, JMSBPP/* = develop forks, all changes reach canonical only via fork → upstream PRs; plus this repo's concrete remote layout and required checks.
- Agent workflow docs (`CLAUDE.md`/`AGENTS.md`/`QWEN.md`) updated so branch/issue/PR commands target the fork for pushes and the canonical repo for issues/PRs.
- This PR itself follows the rule (opened from `JMSBPP:docs/fork-pr-workflow`).

## Linked issue
Closes #113

## Test plan
- [ ] CI green (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTEBW3vLxCzSMZF1rH6BJL