### PR TITLE
refactor: rename Haskell package cfmm-scratchpad -> cfmm-vol-markets-spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog for `cfmm-scratchpad`
+# Changelog for `cfmm-vol-markets-spec`
 
 All notable changes to this project will be documented in this file.
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@
 
 37. ~~**Bring the Lean work into this repo and disassociate from `cfmm-replicationPlank`; name it — repo renamed `cfmm-vol-markets-spec`**~~ — `feat` — [#97](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/97) / [#98](https://github.com/d2p-finance/cfmm-vol-markets-spec/pull/98) ✓ merged (merge commit, history preserved) — `docs/superpowers/specs/2026-08-26-lean-migration-design.md`
    - `lean/{vol_markets,exp,tao}`, `notes/VOLATILITY_INSTRUMENTS.md`, `notes/agents/{exp,vol_markets,tao}` imported with history; Lake files at root; CI `lake build` is a required check (7 min on ubuntu-latest)
-   - open follow-ups: Plank-side deletion of the moved paths + archive `JMSBPP/cfmm-lean4-spec`; dangling links `../refs/DemeterfietalVarianceSwaps.pdf`, `./tbd.md`, `./pos_spec.md`; Haskell package still `cfmm-scratchpad`
+   - open follow-ups: Plank-side deletion of the moved paths + archive `JMSBPP/cfmm-lean4-spec`; dangling links `../refs/DemeterfietalVarianceSwaps.pdf`, `./tbd.md`, `./pos_spec.md`; ~~Haskell package still `cfmm-scratchpad`~~ → renamed `cfmm-vol-markets-spec` ([#114](https://github.com/d2p-finance/cfmm-vol-markets-spec/issues/114))
 
 ## Open
 

--- a/cfmm-vol-markets-spec.cabal
+++ b/cfmm-vol-markets-spec.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 
-name:           cfmm-scratchpad
+name:           cfmm-vol-markets-spec
 version:        0.1.0.0
 description:    Haskell twin of cfmm-vol-markets-spec (spec reference for vol-instruments on CFMMs). See <https://github.com/d2p-finance/cfmm-vol-markets-spec#readme>
 homepage:       https://github.com/d2p-finance/cfmm-vol-markets-spec#readme
@@ -88,9 +88,9 @@ library
       Volatility.VolOrder
       Volatility.VolTermStructure
   other-modules:
-      Paths_cfmm_scratchpad
+      Paths_cfmm_vol_markets_spec
   autogen-modules:
-      Paths_cfmm_scratchpad
+      Paths_cfmm_vol_markets_spec
   hs-source-dirs:
       src
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
@@ -103,12 +103,12 @@ library
     , vector
   default-language: Haskell2010
 
-executable cfmm-scratchpad-exe
+executable cfmm-vol-markets-spec-exe
   main-is: Main.hs
   other-modules:
-      Paths_cfmm_scratchpad
+      Paths_cfmm_vol_markets_spec
   autogen-modules:
-      Paths_cfmm_scratchpad
+      Paths_cfmm_vol_markets_spec
   hs-source-dirs:
       app
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
@@ -116,20 +116,20 @@ executable cfmm-scratchpad-exe
       Chart
     , Chart-cairo
     , base >=4.7 && <5
-    , cfmm-scratchpad
+    , cfmm-vol-markets-spec
     , colour
     , directory
     , mwc-random
     , vector
   default-language: Haskell2010
 
-test-suite cfmm-scratchpad-test
+test-suite cfmm-vol-markets-spec-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
-      Paths_cfmm_scratchpad
+      Paths_cfmm_vol_markets_spec
   autogen-modules:
-      Paths_cfmm_scratchpad
+      Paths_cfmm_vol_markets_spec
   hs-source-dirs:
       test
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N -Wno-name-shadowing -Wno-type-defaults -Wno-gadt-mono-local-binds
@@ -137,7 +137,7 @@ test-suite cfmm-scratchpad-test
       Chart
     , Chart-cairo
     , base >=4.7 && <5
-    , cfmm-scratchpad
+    , cfmm-vol-markets-spec
     , colour
     , mwc-random
     , vector

--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,4 @@
-name:                cfmm-scratchpad
+name:                cfmm-vol-markets-spec
 version:             0.1.0.0
 github:              "d2p-finance/cfmm-vol-markets-spec"
 license:             BSD-3-Clause
@@ -42,7 +42,7 @@ library:
   source-dirs: src
 
 executables:
-  cfmm-scratchpad-exe:
+  cfmm-vol-markets-spec-exe:
     main:                Main.hs
     source-dirs:         app
     ghc-options:
@@ -50,11 +50,11 @@ executables:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - cfmm-scratchpad
+    - cfmm-vol-markets-spec
     - directory
 
 tests:
-  cfmm-scratchpad-test:
+  cfmm-vol-markets-spec-test:
     main:                Spec.hs
     source-dirs:         test
     ghc-options:
@@ -66,4 +66,4 @@ tests:
     - -Wno-type-defaults
     - -Wno-gadt-mono-local-binds
     dependencies:
-    - cfmm-scratchpad
+    - cfmm-vol-markets-spec


### PR DESCRIPTION
## Summary

- Renames the Haskell package `cfmm-scratchpad` → `cfmm-vol-markets-spec`, matching the repo (`refactor`).
- Closes the TODO.md item 37 follow-up "Haskell package still `cfmm-scratchpad`".

The package name was a leftover from `stack new cfmm-scratchpad`. The `github:` and `description:` fields already named the project the package wasn't named after, so every human-facing string disagreed with every build-facing string.

## Linked issue

Closes #114

## Changes

| File | Change |
|---|---|
| `package.yaml` | `name:`, exe stanza, test stanza, internal `build-depends` |
| `cfmm-scratchpad.cabal` → `cfmm-vol-markets-spec.cabal` | regenerated by hpack 0.39.6 (via stack), file renamed |
| `CHANGELOG.md` | heading |
| `TODO.md` | item 37 follow-up struck through |

Binary `cfmm-scratchpad-exe` → `cfmm-vol-markets-spec-exe`.

`.github/workflows/ci.yml` and `README.md` contain no references to the old name — verified with `git grep`. The only remaining occurrences are in `docs/superpowers/plans/2026-08-22-scratchpad-expected-volatility.md`, deliberately left untouched as a historical record of a completed plan.

## Downstream

- **evm-spec-bridge** consumes this package as a Stack `extra-deps` git dependency and had *not* yet committed its pin. It has been told to pin the new name and to wait for this merge SHA. This PR is what makes that pin correct on the first try.
- **cfmm-vol-markets** planning docs reference `cfmm-scratchpad-exe` in the Phase 6 packaging decision; that session has been notified to grep its `.planning/` tree.

## Test plan

- [x] `stack build --dry-run` regenerates `cfmm-vol-markets-spec.cabal` and resolves the package under the new name
- [x] `cabal build all` succeeds (exit 0) — library, exe, and test suite
- [x] `git grep cfmm-scratchpad` returns only the historical plan doc
- [ ] CI green

## Note

A second, larger change is coming as a separate PR: `Chart`/`Chart-cairo`/`colour` are declared at package level, so the library carries a plotting stack. 49 of 62 library modules transitively import Chart, meaning any consumer compiles cairo and pango to reach pure numeric code. Split out separately to keep this rename reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rTZSkgoucAANztktoKJ1G